### PR TITLE
Fix unused import in alembic revision

### DIFF
--- a/alembic/versions/0006_add_indexes.py
+++ b/alembic/versions/0006_add_indexes.py
@@ -1,7 +1,6 @@
 """add indexes to improve lookup speed"""
 
 from alembic import op
-import sqlalchemy as sa
 
 revision = "0006"
 down_revision = "0005"


### PR DESCRIPTION
## Summary
- remove unused sqlalchemy import from 0006_add_indexes migration

## Testing
- `ruff check alembic/versions/0006_add_indexes.py`

------
https://chatgpt.com/codex/tasks/task_e_6850f403e8ac8333805c9037bea50e14