### PR TITLE
Remove unused import from UI tests

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import QApplication, QMainWindow
 from PySide6.QtGui import QCloseEvent
 from src.controllers import MainController
 from src.models import Vehicle, FuelEntry
-from PySide6.QtWidgets import QDialog
 
 
 def test_mainwindow_launch(monkeypatch):


### PR DESCRIPTION
## Summary
- delete unused `QDialog` import from UI smoke tests

## Testing
- `pytest -q tests/test_ui_smoke.py` *(fails: ModuleNotFoundError and AttributeError)*
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6850f4fd58008333ba9be833372755fe