### PR TITLE
Rename variables for clarity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QApplication, QLabel, QMainWindow
+from PySide6.QtWidgets import QApplication, QMainWindow, QLabel
 
 def main() -> None:
     app = QApplication([])

--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -274,8 +274,10 @@ class StorageService:
                 .order_by(month)
             )
             res = []
-            for m, d, l, a in session.exec(stmt):
-                res.append((m, float(d or 0.0), float(l or 0.0), float(a or 0.0)))
+            for m, d, liters_val, amount_val in session.exec(stmt):
+                res.append(
+                    (m, float(d or 0.0), float(liters_val or 0.0), float(amount_val or 0.0))
+                )
             return res
 
     def liters_by_fuel_type(self) -> dict[str | None, float]:
@@ -286,7 +288,10 @@ class StorageService:
                 .where(FuelEntry.liters.is_not(None))
                 .group_by(FuelEntry.fuel_type)
             )
-            return {ft: float(l or 0.0) for ft, l in session.exec(stmt)}
+            return {
+                fuel_type: float(total_liters or 0.0)
+                for fuel_type, total_liters in session.exec(stmt)
+            }
 
     def get_entry(self, entry_id: int) -> Optional[FuelEntry]:
         """ดึงข้อมูลการเติมน้ำมันตามรหัส"""

--- a/tests/test_auto_migration.py
+++ b/tests/test_auto_migration.py
@@ -1,7 +1,6 @@
 from alembic.config import Config
 from alembic import command
 from fueltracker.main import ALEMBIC_INI, run
-from pathlib import Path
 
 
 def test_auto_migration(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- rename loop variables in `monthly_totals`
- rename dictionary comprehension variables in `liters_by_fuel_type`
- remove unused imports flagged by ruff

## Testing
- `ruff check .`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6850f63034848333ba696527ca7adb01