### PR TITLE
Refactor export_report asynchronous

### DIFF
--- a/tests/test_export_report_async.py
+++ b/tests/test_export_report_async.py
@@ -1,0 +1,25 @@
+import time
+from types import MethodType
+from src.controllers.main_controller import MainController
+
+
+def test_export_report_runs_async(qtbot, tmp_path, monkeypatch):
+    ctrl = MainController(db_path=tmp_path / "t.db")
+    qtbot.addWidget(ctrl.window)
+
+    def slow_csv(self, month, year, path):
+        time.sleep(0.2)
+
+    def slow_pdf(self, month, year, path):
+        time.sleep(0.2)
+
+    monkeypatch.setattr(ctrl.exporter, "monthly_csv", MethodType(slow_csv, ctrl.exporter))
+    monkeypatch.setattr(ctrl.exporter, "monthly_pdf", MethodType(slow_pdf, ctrl.exporter))
+
+    start = time.monotonic()
+    ctrl.export_report()
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.05
+
+    with qtbot.waitSignal(ctrl.export_finished, timeout=2000):
+        pass


### PR DESCRIPTION
## Summary
- run export_report using ThreadPoolExecutor
- signal when export tasks finish
- shut down the executor on cleanup
- test that export_report returns immediately

## Testing
- `pytest tests/test_export_report_async.py::test_export_report_runs_async -vv --maxfail=1 -s` *(fails: no output or blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850fb14ee548333a7bf711205f9e6cc