### PR TITLE
Centralize config via pydantic settings

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,8 @@ import os
 from dataclasses import dataclass, asdict
 from pathlib import Path
 
+from .settings import Settings
+
 CONFIG_PATH = Path.home() / ".fueltracker" / "config.json"
 
 
@@ -27,14 +29,14 @@ class AppConfig:
             return cls(
                 default_station=data.get("default_station", "ptt"),
                 update_hours=int(data.get("update_hours", 24)),
-                theme=data.get("theme", "system"),
+                theme=data.get("theme", Settings().ft_theme),
                 hide_on_close=bool(data.get("hide_on_close", os.name == "nt")),
                 global_hotkey_enabled=bool(data.get("global_hotkey_enabled", True)),
                 hotkey=data.get("hotkey", "Ctrl+Shift+N"),
                 start_minimized=bool(data.get("start_minimized", False)),
             )
         except Exception:
-            return cls()
+            return cls(theme=Settings().ft_theme)
 
     def save(self, path: Path | None = None) -> None:
         path = path or CONFIG_PATH

--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -328,8 +328,9 @@ class MainController(QObject):
         if os.name != "nt":
             QMessageBox.information(self.window, "ไม่รองรับ", "ใช้ได้เฉพาะบน Windows")
             return
+        startup_base = self.env.appdata or ""
         startup = (
-            Path(os.getenv("APPDATA", ""))
+            Path(startup_base)
             / "Microsoft"
             / "Windows"
             / "Start Menu"

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -11,8 +12,6 @@ class Settings(BaseSettings):
     ft_theme: str = Field(default="system")
     ft_db_password: str | None = None
     ft_cloud_dir: Path | None = None
+    appdata: Path | None = Field(default=None, validation_alias="APPDATA")
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False, env_prefix="")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from src.settings import Settings
+
+
+def test_env_loading(monkeypatch, tmp_path):
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "my.db"))
+    monkeypatch.setenv("FT_THEME", "modern")
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    settings = Settings()
+    assert settings.db_path == tmp_path / "my.db"
+    assert settings.ft_theme == "modern"
+    assert settings.appdata == tmp_path / "appdata"


### PR DESCRIPTION
## Summary
- add `Settings` using `pydantic-settings`
- use `Settings` in `AppConfig` and `MainController`
- add regression tests for environment loading

## Testing
- `pytest tests/test_settings.py tests/test_theme.py tests/test_exporter_service.py::test_exporter_creates_files -q`

------
https://chatgpt.com/codex/tasks/task_e_6851039c3fa88333a843148c291f1508