### PR TITLE
Fix unused import in tests

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from src.settings import Settings
 
 


### PR DESCRIPTION
## Summary
- remove unused `pathlib.Path` import from `tests/test_settings.py`

## Testing
- `ruff check . -q`


------
https://chatgpt.com/codex/tasks/task_e_685126142d148333ac2f267a22e4b789