### PR TITLE
Use queued invoke for price updates

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -31,6 +31,7 @@ from PySide6.QtGui import (
 )
 from PySide6.QtCore import (
     Qt,
+    QMetaObject,
     QObject,
     Signal,
     QEvent,
@@ -1093,7 +1094,11 @@ class MainController(QObject):
                 try:
                     with Session(self.controller.storage.engine) as sess:
                         fetch_latest(sess, self.controller.config.default_station)
-                        self.controller._load_prices()
+                        QMetaObject.invokeMethod(
+                            self.controller,
+                            self.controller._load_prices,
+                            Qt.QueuedConnection,
+                        )
                 except requests.RequestException as exc:  # pragma: no cover - network
                     logging.error("Failed to update oil prices: %s", exc)
                     if os.name == "nt":

--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -97,6 +97,10 @@ def test_price_update_handles_error(qapp, monkeypatch, tmp_path):
 
     monkeypatch.setattr(QTimer, "singleShot", fake_single_shot)
     monkeypatch.setattr(MainController, "_load_prices", lambda self: None)
+    monkeypatch.setattr(
+        "src.controllers.main_controller.QMetaObject.invokeMethod",
+        lambda *a, **k: called.setdefault("invoked", True),
+    )
 
     def raise_error(*_a, **_k):
         raise requests.RequestException("fail")


### PR DESCRIPTION
## Summary
- import `QMetaObject` for scheduling updates
- call `_load_prices` via `invokeMethod`
- update tests to mock `invokeMethod`

## Testing
- `pytest tests/test_oil_service.py tests/test_preferences.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851279ecb3c8333b36ec438493cadd8