### PR TITLE
Fix budget migration re-run failure

### DIFF
--- a/alembic/versions/0002_add_budgets.py
+++ b/alembic/versions/0002_add_budgets.py
@@ -3,6 +3,13 @@
 from alembic import op
 import sqlalchemy as sa
 
+
+def _table_absent(table: str) -> bool:
+    """Return True if the given table is not present in the database."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table not in inspector.get_table_names()
+
 revision = "0002"
 down_revision = "0001"
 branch_labels = None
@@ -10,13 +17,15 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "budget",
-        sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("vehicle_id", sa.Integer, nullable=False),
-        sa.Column("amount", sa.Float, nullable=False),
-    )
+    if _table_absent("budget"):
+        op.create_table(
+            "budget",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("vehicle_id", sa.Integer, nullable=False),
+            sa.Column("amount", sa.Float, nullable=False),
+        )
 
 
 def downgrade() -> None:
-    op.drop_table("budget")
+    if not _table_absent("budget"):
+        op.drop_table("budget")


### PR DESCRIPTION
## Summary
- avoid failing if the `budget` table already exists by checking with `_table_absent`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68512eae9d308333ae6c34e7583a2d61