### PR TITLE
Fix QMetaObject.invokeMethod misuse in updater

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -1100,11 +1100,7 @@ class MainController(QObject):
                 try:
                     with Session(self.controller.storage.engine) as sess:
                         fetch_latest(sess, self.controller.config.default_station)
-                        QMetaObject.invokeMethod(
-                            self.controller,
-                            self.controller._load_prices,
-                            Qt.ConnectionType.QueuedConnection,
-                        )
+                        QTimer.singleShot(0, self.controller._load_prices)
                 except requests.RequestException as exc:  # pragma: no cover - network
                     logging.error("Failed to update oil prices: %s", exc)
                     if os.name == "nt":


### PR DESCRIPTION
## Summary
- replace QMetaObject.invokeMethod with QTimer.singleShot when loading prices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68515eb62ed88333994b22ea459862cb