### PR TITLE
Handle pytest output in connectivity script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,8 @@ keyboard
 pydantic-settings
 types-keyboard
 types-reportlab
+alembic
+mypy
+pydeps
+ruff
+vulture

--- a/scripts/validate_connectivity.py
+++ b/scripts/validate_connectivity.py
@@ -11,9 +11,22 @@ REPORTS = Path("reports")
 REPORTS.mkdir(exist_ok=True)
 
 
-def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+def run(cmd: list[str], *, capture: bool = True, **kwargs) -> subprocess.CompletedProcess[str]:
+    """Run *cmd* and optionally capture output.
+
+    Parameters
+    ----------
+    cmd: list[str]
+        Command and arguments to run.
+    capture: bool, optional
+        Capture stdout/stderr if ``True`` (default) or inherit the current
+        process streams if ``False``.
+    """
+
     print("$", " ".join(cmd))
-    return subprocess.run(cmd, text=True, capture_output=True, **kwargs)
+    if capture:
+        return subprocess.run(cmd, text=True, capture_output=True, **kwargs)
+    return subprocess.run(cmd, text=True, **kwargs)
 
 
 def main() -> None:
@@ -83,8 +96,8 @@ def main() -> None:
         errors.append("migrate")
 
     # 5. Pytest
-    res = run(["pytest", "-q"])
-    (REPORTS / "pytest.txt").write_text(res.stdout + res.stderr)
+    res = run(["pytest", "-q"], capture=False)
+    (REPORTS / "pytest.txt").write_text((res.stdout or "") + (res.stderr or ""))
     summary.append("Pytest exit: " + str(res.returncode))
     if res.returncode != 0:
         errors.append("pytest")

--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -31,7 +31,7 @@ from PySide6.QtGui import (
 )
 from PySide6.QtCore import (
     Qt,
-    QMetaObject,
+    QMetaObject,  # noqa: F401 - used for monkeypatching in tests
     QObject,
     Signal,
     QEvent,


### PR DESCRIPTION
## Summary
- allow toggling output capture in validate_connectivity helper
- show pytest progress in validate_connectivity script
- keep `QMetaObject` import for tests
- include dev utilities in requirements

## Testing
- `ruff check .`
- `mypy src/ --strict` *(fails: Cannot find implementation or library stub for module named 'PySide6.QtWidgets')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6851675a907c833397f97c80d4ce2647