### PR TITLE
Fix prefill logic and price update scheduling

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -835,14 +835,14 @@ class MainController(QObject):
             last = repo.last_entry(vid)
             if last is not None and last.odo_after is not None:
                 dialog.odoBeforeEdit.setText(str(last.odo_after))
+                dialog.odoAfterEdit.setText(str(last.odo_after))
             else:
                 dialog.odoBeforeEdit.clear()
-            dialog.odoAfterEdit.clear()
+                dialog.odoAfterEdit.clear()
             dialog.amountEdit.clear()
             dialog.litersEdit.clear()
             dialog.odoAfterEdit.setReadOnly(True)
             dialog.litersEdit.setReadOnly(True)
-            _auto_fill()
 
         for v in self.storage.list_vehicles():
             dialog.vehicleComboBox.addItem(v.name, v.id)
@@ -1100,7 +1100,11 @@ class MainController(QObject):
                 try:
                     with Session(self.controller.storage.engine) as sess:
                         fetch_latest(sess, self.controller.config.default_station)
-                        QTimer.singleShot(0, self.controller._load_prices)
+                        QMetaObject.invokeMethod(
+                            self.controller,
+                            "_load_prices",
+                            Qt.ConnectionType.QueuedConnection,
+                        )
                 except requests.RequestException as exc:  # pragma: no cover - network
                     logging.error("Failed to update oil prices: %s", exc)
                     if os.name == "nt":


### PR DESCRIPTION
## Summary
- correct odometer prefill behavior when opening the Add Entry dialog
- schedule price update using QMetaObject.invokeMethod
- install project in editable mode for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685226e89e1c8333acc1ce03fd8ba986