### PR TITLE
Fix hotkey callback return type

### DIFF
--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -22,7 +22,7 @@ class GlobalHotkey(QObject):
         try:
             keyboard.add_hotkey(
                 self._format(self.sequence),
-                lambda: self.triggered.emit(),
+                lambda: (self.triggered.emit() or False),
             )
         except Exception:  # pragma: no cover - ignore environments without input devices
             return


### PR DESCRIPTION
## Summary
- ensure GlobalHotkey callback returns a bool so `keyboard` accepts it

## Testing
- `pytest tests/test_hotkey.py::test_start_stop -q`
- `pytest -q` *(fails: test suite stalled; attempted but interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68522e0c7fb4833392d980d777c4ddc8