### PR TITLE
Add main_controller fixture for test reuse

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "src"))
 
 from src.services import StorageService  # noqa: E402
+from src.controllers.main_controller import MainController  # noqa: E402
 
 
 @pytest.fixture
@@ -36,3 +37,11 @@ def qapp():
     if app is None:
         app = QApplication([])
     return app
+
+
+@pytest.fixture
+def main_controller(qapp, tmp_path):
+    """Return a MainController using a temporary database."""
+    ctrl = MainController(db_path=tmp_path / "t.db")
+    yield ctrl
+    ctrl.cleanup()

--- a/tests/test_budget_alert.py
+++ b/tests/test_budget_alert.py
@@ -1,12 +1,11 @@
 from datetime import date
 from PySide6.QtWidgets import QMessageBox
 
-from src.controllers.main_controller import MainController
 from src.models import FuelEntry, Vehicle
 
 
-def test_budget_warning(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_budget_warning(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)

--- a/tests/test_budget_settings.py
+++ b/tests/test_budget_settings.py
@@ -2,12 +2,11 @@ from datetime import date
 
 from PySide6.QtWidgets import QMessageBox
 
-from src.controllers.main_controller import MainController
 from src.models import Vehicle, FuelEntry
 
 
-def test_budget_save_updates_storage(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_budget_save_updates_storage(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)

--- a/tests/test_export_report_async.py
+++ b/tests/test_export_report_async.py
@@ -1,11 +1,10 @@
 import time
 from types import MethodType
 from PySide6.QtWidgets import QMessageBox
-from src.controllers.main_controller import MainController
 
 
-def test_export_report_runs_async(qtbot, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_export_report_runs_async(qtbot, main_controller, monkeypatch):
+    ctrl = main_controller
     qtbot.addWidget(ctrl.window)
 
     # Prevent the QMessageBox connected to the signal from blocking the test

--- a/tests/test_filter_entries.py
+++ b/tests/test_filter_entries.py
@@ -1,12 +1,11 @@
 from datetime import date, timedelta
 from PySide6.QtCore import QDate
-from src.controllers.main_controller import MainController
 from src.models import FuelEntry, Vehicle, Maintenance
 from src.services import StorageService
 
 
-def test_filter_entries(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_filter_entries(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(Vehicle(name="Car A", vehicle_type="t", license_plate="a", tank_capacity_liters=1))
     storage.add_vehicle(Vehicle(name="Car B", vehicle_type="t", license_plate="b", tank_capacity_liters=1))
@@ -72,8 +71,8 @@ def test_list_entries_filtered(tmp_path):
     assert res[0].vehicle_id == 2
 
 
-def test_last_entry_tooltip_and_maintenance(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_last_entry_tooltip_and_maintenance(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(name="Car", vehicle_type="t", license_plate="x", tank_capacity_liters=1)

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,8 +1,5 @@
-from src.controllers.main_controller import MainController
-
-
-def test_sidebar_icons(qapp, tmp_path):
-    controller = MainController(db_path=tmp_path / "db.sqlite")
+def test_sidebar_icons(main_controller):
+    controller = main_controller
     sidebar = controller.window.sidebarList
     assert sidebar.count() == 4
     for i in range(sidebar.count()):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -8,7 +8,6 @@ from sqlalchemy.pool import StaticPool
 from src.models import FuelEntry, Vehicle
 from src.services import StorageService, Exporter
 from src.services.importer import Importer
-from src.controllers.main_controller import MainController
 from src.views import load_add_entry_dialog
 from PySide6.QtWidgets import QDialog
 
@@ -99,8 +98,8 @@ def test_import_many_single_transaction(tmp_path: Path):
     assert commit_count - start == 1
 
 
-def test_prefill_odometer(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_prefill_odometer(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(

--- a/tests/test_maintenance_dock.py
+++ b/tests/test_maintenance_dock.py
@@ -1,8 +1,5 @@
-from src.controllers.main_controller import MainController
-
-
-def test_dock_buttons_exist(qapp, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_dock_buttons_exist(main_controller):
+    ctrl = main_controller
     dock = ctrl.maint_dock
     assert dock.add_button.text()
     assert dock.edit_button.text()

--- a/tests/test_maintenance_notification.py
+++ b/tests/test_maintenance_notification.py
@@ -1,13 +1,12 @@
 from datetime import date
 from PySide6.QtWidgets import QMessageBox
 
-from src.controllers import main_controller
-from src.controllers.main_controller import MainController
+from src.controllers import main_controller as main_module
 from src.models import Vehicle, Maintenance
 
 
-def test_maintenance_notification(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_maintenance_notification(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
@@ -18,9 +17,9 @@ def test_maintenance_notification(qapp, tmp_path, monkeypatch):
         QMessageBox, "information", lambda *a, **k: notified.setdefault("n", True)
     )
     show = {}
-    monkeypatch.setattr(main_controller.os, "name", "nt", raising=False)
+    monkeypatch.setattr(main_module.os, "name", "nt", raising=False)
     monkeypatch.setattr(
-        main_controller.ToastNotifier,
+        main_module.ToastNotifier,
         "show_toast",
         lambda *a, **k: show.setdefault("t", True),
     )

--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -57,8 +57,8 @@ def test_fetch_latest(monkeypatch, in_memory_storage):
         assert len(rows) == 12
 
 
-def test_autofill_liters(qapp, monkeypatch, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_autofill_liters(main_controller, monkeypatch):
+    ctrl = main_controller
     ctrl.storage.add_vehicle(
         Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
     )
@@ -86,8 +86,8 @@ def test_autofill_liters(qapp, monkeypatch, tmp_path):
     assert dialog.litersEdit.text() == "2.00"
 
 
-def test_price_update_handles_error(qapp, monkeypatch, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_price_update_handles_error(main_controller, monkeypatch):
+    ctrl = main_controller
 
     monkeypatch.setattr(ctrl.thread_pool, "start", lambda job: job.run())
     called = {}

--- a/tests/test_page_switch.py
+++ b/tests/test_page_switch.py
@@ -1,7 +1,5 @@
-from src.controllers.main_controller import MainController
-
-def test_switch_page_changes_index(qtbot, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_switch_page_changes_index(qtbot, main_controller):
+    ctrl = main_controller
     window = ctrl.window
     qtbot.addWidget(window)
     stack = window.stackedWidget

--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -1,11 +1,10 @@
-from src.controllers.main_controller import MainController
 from src.models import Vehicle
 from src.services.report_service import ReportService
 import pandas as pd
 
 
-def test_refresh_updates_summary(qtbot, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_refresh_updates_summary(qtbot, main_controller):
+    ctrl = main_controller
     page = ctrl.reports_page
     qtbot.addWidget(page)
     with qtbot.waitSignal(page.refresh_requested, timeout=2000):
@@ -13,8 +12,8 @@ def test_refresh_updates_summary(qtbot, tmp_path):
     assert "km" in page.cards["distance"].value_label.text()
 
 
-def test_monthly_tab_populates(qtbot, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_monthly_tab_populates(qtbot, main_controller):
+    ctrl = main_controller
     page = ctrl.reports_page
     qtbot.addWidget(page)
     with qtbot.waitSignal(page.refresh_requested, timeout=2000):
@@ -22,8 +21,8 @@ def test_monthly_tab_populates(qtbot, tmp_path):
     assert page.monthly_layout.count() > 0
 
 
-def test_refresh_clears_worker(qtbot, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_refresh_clears_worker(qtbot, main_controller):
+    ctrl = main_controller
     page = ctrl.reports_page
     qtbot.addWidget(page)
     with qtbot.waitSignal(page.refresh_requested, timeout=2000):
@@ -31,8 +30,8 @@ def test_refresh_clears_worker(qtbot, tmp_path):
     qtbot.waitUntil(lambda: page._worker is None, timeout=2000)
 
 
-def test_vehicle_selection_updates_monthly(qtbot, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_vehicle_selection_updates_monthly(qtbot, main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(name="v1", vehicle_type="t", license_plate="x", tank_capacity_liters=1)

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -3,7 +3,6 @@ import sys
 from datetime import date
 from PySide6.QtWidgets import QApplication, QMainWindow
 from PySide6.QtGui import QCloseEvent
-from src.controllers import MainController
 from src.models import Vehicle, FuelEntry
 
 
@@ -21,8 +20,8 @@ def test_mainwindow_launch(monkeypatch):
     assert shown
 
 
-def test_close_hides_window(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_close_hides_window(main_controller, monkeypatch):
+    ctrl = main_controller
     window = ctrl.window
     monkeypatch.setattr(ctrl.tray_icon, "isVisible", lambda: True)
     ctrl.config.hide_on_close = True
@@ -34,8 +33,8 @@ def test_close_hides_window(qapp, tmp_path, monkeypatch):
     assert hidden.get("h")
 
 
-def test_tray_tooltip_updates(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_tray_tooltip_updates(main_controller, monkeypatch):
+    ctrl = main_controller
     storage = ctrl.storage
     storage.add_vehicle(
         Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
@@ -57,8 +56,8 @@ def test_tray_tooltip_updates(qapp, tmp_path, monkeypatch):
     assert tip.get("v")
 
 
-def test_hotkey_invokes_dialog(qapp, tmp_path, monkeypatch):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_hotkey_invokes_dialog(main_controller, monkeypatch):
+    ctrl = main_controller
     called = {}
     monkeypatch.setattr(ctrl, "open_add_entry_dialog", lambda: called.setdefault("ok", True))
     ctrl.window.hide()
@@ -69,8 +68,8 @@ def test_hotkey_invokes_dialog(qapp, tmp_path, monkeypatch):
     assert visible.get("v")
 
 
-def test_cleanup_unregisters_hotkey(qapp, tmp_path):
-    ctrl = MainController(db_path=tmp_path / "t.db")
+def test_cleanup_unregisters_hotkey(main_controller):
+    ctrl = main_controller
     # Hotkeys are enabled by default, so a GlobalHotkey instance should exist
     assert ctrl.global_hotkey is not None
     ctrl.cleanup()


### PR DESCRIPTION
## Summary
- add `main_controller` fixture in test suite
- refactor tests to use the new fixture instead of manual `MainController` setup

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6852326f7c4083339e858b9c4fda837c