### PR TITLE
Bump required Python to 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## ความต้องการ
 
-- Python 3.12
+ - Python 3.13 or later
 - ติดตั้งแพ็กเกจที่ระบุใน `requirements.txt`
 
 ## การติดตั้ง

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "fueltracker"
 version = "0.1.0"
 description = "Fuel tracker sample application"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 authors = [{name="Example", email="example@example.com"}]
 dependencies = [
     "PySide6>=6.7",


### PR DESCRIPTION
## Summary
- require Python 3.13 or higher
- update README to mention Python 3.13

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_685235758a9883338705cc401e1d3d13