### PR TITLE
Fix cleanup with destroyed windows

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -1190,8 +1190,12 @@ class MainController(QObject):
                 self.window.removeEventFilter(self)
             except RuntimeError:
                 pass
-        self.settings.setValue("windowGeometry", self.window.saveGeometry())
-        self.settings.setValue("windowState", self.window.saveState())
+        try:
+            self.settings.setValue("windowGeometry", self.window.saveGeometry())
+            self.settings.setValue("windowState", self.window.saveState())
+        except RuntimeError:
+            # Window already destroyed
+            pass
         self._unregister_hotkey()
         self.executor.shutdown(wait=False)
 


### PR DESCRIPTION
## Summary
- handle destroyed windows in `cleanup`

## Testing
- `pytest tests/test_export_report_async.py::test_export_report_runs_async tests/test_page_switch.py::test_switch_page_changes_index tests/test_reports.py::test_export_pdf_cleanup_on_error -q`

------
https://chatgpt.com/codex/tasks/task_e_6852366c6ef083339d4d7285a01b79b7