### PR TITLE
Fix migrations and headless pdf export

### DIFF
--- a/src/fueltracker/main.py
+++ b/src/fueltracker/main.py
@@ -35,8 +35,8 @@ def run(argv: list[str] | None = None) -> None:
         upgrade(Config(ALEMBIC_INI), "head")
         return
 
-    if not args.check:
-        upgrade(Config(ALEMBIC_INI), "head")
+    # Always apply any pending migrations before launching the app
+    upgrade(Config(ALEMBIC_INI), "head")
 
     logging.basicConfig(level=logging.INFO)
     if args.check:

--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -8,6 +8,10 @@ from typing import Dict, List
 
 import pandas as pd
 from fpdf import FPDF
+import matplotlib
+
+# Use a non-interactive backend for headless environments
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from ..models import FuelEntry, Vehicle


### PR DESCRIPTION
## Summary
- upgrade the database to `head` for check mode
- force Matplotlib to use `Agg` backend for PDF exports so tests run headlessly

## Testing
- `ruff check .`
- `pytest -k test_auto_migration -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685240bf73d08333865a8b4d9176d4e3