### PR TITLE
Fix hotkey mypy import

### DIFF
--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QObject, Signal
+from typing import Any
 
+kb: Any | None
 try:
-    import keyboard
+    import keyboard as kb
 except Exception:  # pragma: no cover - optional dependency
-    keyboard = None  # type: ignore
+    kb = None
+keyboard = kb  # FIX: mypy clean
 
 
 class GlobalHotkey(QObject):


### PR DESCRIPTION
## Summary
- clean up keyboard optional import in `src/hotkey.py`

## Testing
- `ruff check src/hotkey.py`
- `mypy src/hotkey.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68525a4b5edc8333a9499bda75dff0c6