### PR TITLE
Update hotkey tests for listener callback

### DIFF
--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -9,23 +9,54 @@ def test_format_basic():
 
 
 def test_start_stop(monkeypatch):
-    calls = {"add": 0, "remove": 0}
+    calls: dict[str, int] = {
+        "add": 0,
+        "remove": 0,
+        "listener_start": 0,
+        "listener_stop": 0,
+        "callback": 0,
+    }
 
-    def fake_add_hotkey(seq: str, cb):
+    def fake_add_hotkey(seq: str, cb) -> None:
         calls["add"] += 1
         cb()
 
-    def fake_remove_hotkey(seq: str):
+    def fake_remove_hotkey(seq: str) -> None:
         calls["remove"] += 1
 
-    stub = SimpleNamespace(add_hotkey=fake_add_hotkey, remove_hotkey=fake_remove_hotkey)
+    class FakeListener:
+        def __init__(self, mapping: dict[str, object]):
+            self.mapping = mapping
+
+        def start(self) -> None:
+            calls["listener_start"] += 1
+            for cb in self.mapping.values():
+                cb()
+
+        def stop(self) -> None:
+            calls["listener_stop"] += 1
+
+    stub = SimpleNamespace(
+        add_hotkey=fake_add_hotkey,
+        remove_hotkey=fake_remove_hotkey,
+        GlobalHotKeys=lambda mapping: FakeListener(mapping),
+    )
     monkeypatch.setattr("src.hotkey.keyboard", stub)
 
+    original = GlobalHotkey._wrapped_callback
+
+    def patched(self: GlobalHotkey) -> int:
+        calls["callback"] += 1
+        return original(self)
+
+    monkeypatch.setattr(GlobalHotkey, "_wrapped_callback", patched)
+
     gh = GlobalHotkey("Ctrl+Shift+N")
-    triggered = []
+    triggered: list[bool] = []
     gh.triggered.connect(lambda: triggered.append(True))
     gh.start()
-    assert calls["add"] == 1
+    assert calls["listener_start"] == 1
+    assert calls["callback"] == 1
     assert triggered == [True]
     gh.stop()
-    assert calls["remove"] == 1
+    assert calls["listener_stop"] == 1


### PR DESCRIPTION
## Summary
- patch `GlobalHotkey._wrapped_callback` in tests
- simulate GlobalHotKeys listener when registering hotkeys

## Testing
- `pytest -q tests/test_hotkey.py`

------
https://chatgpt.com/codex/tasks/task_e_68526b6869f88333a4026fd3845c9770