### PR TITLE
fix: prevent SQLAlchemy refresh hang and add timeout to connectivity script

### DIFF
--- a/scripts/validate_connectivity.py
+++ b/scripts/validate_connectivity.py
@@ -45,8 +45,19 @@ def run(
 
     print("$", " ".join(cmd))
     if capture:
-        return subprocess.run(cmd, text=True, capture_output=True, env=env, **kwargs)
-    return subprocess.run(cmd, text=True, env=env, **kwargs)
+        # FIX: prevent endless subprocess hang
+        result = subprocess.run(
+            cmd,
+            text=True,
+            env=env,
+            capture_output=True,
+            timeout=60,
+            **kwargs,
+        )
+        print(result.stdout)
+        print(result.stderr)
+        return result
+    return subprocess.run(cmd, text=True, env=env, timeout=60, **kwargs)
 
 
 def main() -> None:

--- a/src/repositories/fuel_entry_repo.py
+++ b/src/repositories/fuel_entry_repo.py
@@ -37,5 +37,8 @@ class FuelEntryRepository:
         with Session(self.engine) as sess:
             sess.add(entry)
             sess.commit()
-            sess.refresh(entry)
+            # FIX: prevent hang
+            sess.flush()
+            if entry.id is not None:
+                sess.refresh(entry)
             return entry

--- a/src/services/importer.py
+++ b/src/services/importer.py
@@ -64,7 +64,10 @@ class Importer:
         with Session(self.storage.engine) as session:
             session.add_all(entries)
             session.commit()
+            # FIX: prevent hang
+            session.flush()
             for e in entries:
-                session.refresh(e)
+                if e.id is not None:
+                    session.refresh(e)
 
         return entries

--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -158,13 +158,19 @@ class StorageService:
 
             session.add(entry)
             session.commit()
-            session.refresh(entry)
+            # FIX: prevent hang when entry.id is None
+            session.flush()
+            if entry.id is not None:
+                session.refresh(entry)
 
     def add_vehicle(self, vehicle: Vehicle) -> None:
         with Session(self.engine) as session:
             session.add(vehicle)
             session.commit()
-            session.refresh(vehicle)
+            # FIX: prevent hang when vehicle.id is None
+            session.flush()
+            if vehicle.id is not None:
+                session.refresh(vehicle)
 
     def list_entries(self) -> List[FuelEntry]:
         with Session(self.engine) as session:
@@ -203,7 +209,10 @@ class StorageService:
         with Session(self.engine) as session:
             session.add(vehicle)
             session.commit()
-            session.refresh(vehicle)
+            # FIX: prevent hang when vehicle.id is None
+            session.flush()
+            if vehicle.id is not None:
+                session.refresh(vehicle)
 
     def delete_vehicle(self, vehicle_id: int) -> None:
         """ลบยานพาหนะออกจากฐานข้อมูล"""
@@ -324,7 +333,10 @@ class StorageService:
         with Session(self.engine) as session:
             session.add(entry)
             session.commit()
-            session.refresh(entry)
+            # FIX: prevent hang when entry.id is None
+            session.flush()
+            if entry.id is not None:
+                session.refresh(entry)
 
     def delete_entry(self, entry_id: int) -> None:
         """ลบข้อมูลการเติมน้ำมันออกจากฐานข้อมูล"""
@@ -342,7 +354,10 @@ class StorageService:
         with Session(self.engine) as session:
             session.add(task)
             session.commit()
-            session.refresh(task)
+            # FIX: prevent hang
+            session.flush()
+            if task.id is not None:
+                session.refresh(task)
 
     def list_maintenances(self, vehicle_id: int | None = None) -> List[Maintenance]:
         with Session(self.engine) as session:
@@ -359,7 +374,10 @@ class StorageService:
         with Session(self.engine) as session:
             session.add(task)
             session.commit()
-            session.refresh(task)
+            # FIX: prevent hang
+            session.flush()
+            if task.id is not None:
+                session.refresh(task)
 
     def mark_maintenance_done(self, task_id: int, done: bool = True) -> None:
         with Session(self.engine) as session:
@@ -369,7 +387,10 @@ class StorageService:
             task.is_done = done
             session.add(task)
             session.commit()
-            session.refresh(task)
+            # FIX: prevent hang
+            session.flush()
+            if task.id is not None:
+                session.refresh(task)
 
     def list_due_maintenances(
         self,


### PR DESCRIPTION
## Summary
- guard refresh calls when PK might be None
- flush before refresh in storage and importer services
- add timeout and logging for subprocess call in validate_connectivity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic.config')*
- `python scripts/validate_connectivity.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'vulture')*

------
https://chatgpt.com/codex/tasks/task_e_68526e9a676c8333a8249b75cddff5a9