### PR TITLE
Fix connectivity script timeout

### DIFF
--- a/scripts/validate_connectivity.py
+++ b/scripts/validate_connectivity.py
@@ -51,13 +51,13 @@ def run(
             text=True,
             env=env,
             capture_output=True,
-            timeout=60,
+            timeout=300,
             **kwargs,
         )
         print(result.stdout)
         print(result.stderr)
         return result
-    return subprocess.run(cmd, text=True, env=env, timeout=60, **kwargs)
+    return subprocess.run(cmd, text=True, env=env, timeout=300, **kwargs)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- extend timeout for subprocess runs from 60s to 300s in `validate_connectivity.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685278294d2883339551f7802fe39ec2