### PR TITLE
Add README section on Poe tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,31 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+## Using Poe the Poet
+
+ติดตั้ง `Poe the Poet` เพื่อจัดการงานต่าง ๆ ภายในโปรเจ็กต์ได้ด้วย
+
+```bash
+pip install poe-the-poet
+```
+
+หรือใช้ตัวเลือกสำหรับนักพัฒนา
+
+```bash
+pip install -e .[dev]
+```
+
+งานที่มีให้ใช้งานประกอบด้วย
+
+- `poe lint`
+- `poe test`
+- `poe migrate`
+- `poe runtime-check`
+- `poe build`
+- `poe validate`
+
+คำสั่งเหล่านี้กำหนดไว้ในไฟล์ `pyproject.toml` สามารถเรียกใช้ได้ตามต้องการ
+
 ## การตั้งค่า
 
 คัดลอก `.env.example` ไปเป็น `.env` แล้วปรับค่าตามต้องการ


### PR DESCRIPTION
## Summary
- document Poe the Poet usage in `README`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685286aa93b083338c948c6627f4b3ff