### PR TITLE
Fix Python version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## ความต้องการ
 
- - Python 3.13 or later
+ - Python 3.11 or later
 - ติดตั้งแพ็กเกจที่ระบุใน `requirements.txt`
 
 ## การติดตั้ง

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "fueltracker"
 version = "0.1.0"
 description = "Fuel tracker sample application"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 authors = [{name="Example", email="example@example.com"}]
 dependencies = [
     "PySide6>=6.7",


### PR DESCRIPTION
## Summary
- set minimum supported Python to 3.11
- update docs to mention Python 3.11 instead of 3.13

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_685287e9823c8333b365eecfcb74bf2a