### PR TITLE
Fix imports in report_service

### DIFF
--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -18,11 +18,11 @@ import matplotlib.pyplot as plt
 from matplotlib import dates as mdates
 from typing import Callable, cast
 
-date2num = cast(Callable[[date], float], mdates.date2num)
-
 from ..models import FuelEntry, Vehicle
 from .storage_service import StorageService
 from ..constants import FUEL_TYPE_TH
+
+date2num = cast(Callable[[date], float], mdates.date2num)
 
 
 class ReportService:


### PR DESCRIPTION
## Summary
- move internal imports above variable initialization in `report_service.py`

## Testing
- `ruff check src`
- `mypy src/ --strict` *(fails: `SQLModel` stubs missing, etc.)*
- `vulture src/` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6852d137d46083338f5d47d562e907c0