### PR TITLE
Fix mypy issues

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -71,7 +71,7 @@ import logging
 import os
 import sys
 from datetime import timedelta, datetime
-import requests
+import requests  # type: ignore[import-untyped]
 
 from ..settings import Settings
 
@@ -148,7 +148,8 @@ class OilPricesDock(QDockWidget):
         self.table = QTableWidget(0, 3)
         self.table.setHorizontalHeaderLabels(["วันที่", "ประเภทเชื้อเพลิง", "ราคา"])
         self.figure = Figure(figsize=(4, 3))
-        self.canvas = FigureCanvasQTAgg(self.figure)
+        # ``FigureCanvasQTAgg`` comes from ``matplotlib`` which is not fully typed
+        self.canvas = FigureCanvasQTAgg(self.figure)  # type: ignore[no-untyped-call]
         widget = QWidget()
         layout = QVBoxLayout(widget)
         layout.addWidget(self.table)

--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -4,11 +4,12 @@ from PySide6.QtCore import QObject, Signal
 from typing import Any
 
 try:
-    import keyboard as kb
+    import keyboard as kb_module
 except Exception:  # pragma: no cover - optional dependency
-    kb = None
+    kb_module = None
 
-keyboard: Any | None = kb
+# Optional keyboard module, may be ``None`` when dependency is missing
+keyboard: Any | None = kb_module
 
 
 class GlobalHotkey(QObject):
@@ -42,7 +43,6 @@ class GlobalHotkey(QObject):
                 keyboard.add_hotkey(
                     self._format(self.sequence),
                     self._wrapped_callback,
-                    # type: ignore[arg-type]
                 )
         except Exception:  # pragma: no cover - ignore environments without input devices
             return

--- a/src/services/oil_service.py
+++ b/src/services/oil_service.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, Optional, cast
 
-import requests
+import requests  # type: ignore[import-untyped]
 from sqlmodel import Session, select
 
 from ..models import FuelPrice


### PR DESCRIPTION
## Summary
- silence requests import errors for mypy
- clean up GlobalHotkey module detection and remove unused ignore
- ignore untyped call to FigureCanvasQTAgg

## Testing
- `mypy src/hotkey.py src/services/oil_service.py src/controllers/main_controller.py`
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6852d5d0ecf48333b0bf32ac262639c3