### PR TITLE
Fix vulture whitelist path

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -1,31 +1,43 @@
-# Vulture whitelist
-# This file tells Vulture to ignore false positives.
+"""Objects referenced to avoid vulture false positives."""
 
-# --- Attributes/Methods from main_controller.py that are used by Qt ---
-main_controller.closeEvent
-main_controller._load_prices
+from src.controllers import main_controller, undo_commands
+from src.services import (
+    exporter,
+    importer,
+    report_service,
+    storage_service,
+)
+from src import settings
 
-# --- Methods from undo_commands.py that are used by QUndoStack ---
-undo_commands.AddEntryCommand.undo
-undo_commands.AddEntryCommand.redo
-undo_commands.DeleteEntryCommand.undo
-undo_commands.DeleteEntryCommand.redo
-undo_commands.AddVehicleCommand.undo
-undo_commands.AddVehicleCommand.redo
-undo_commands.DeleteVehicleCommand.undo
-undo_commands.DeleteVehicleCommand.redo
-undo_commands.UpdateVehicleCommand.undo
-undo_commands.UpdateVehicleCommand.redo
+_ = (
+    # --- Attributes/Methods from main_controller.py that are used by Qt ---
+    main_controller.closeEvent,
+    main_controller._load_prices,
 
-# --- Methods that might be used by UI or future features ---
-exporter.monthly_excel
-importer.import_csv
-report_service.generate_report
-report_service.export_csv
-report_service.export_pdf
-report_service.export_excel
-storage_service.get_entries_by_vehicle
-storage_service.update_entry
+    # --- Methods from undo_commands.py that are used by QUndoStack ---
+    undo_commands.AddEntryCommand.undo,
+    undo_commands.AddEntryCommand.redo,
+    undo_commands.DeleteEntryCommand.undo,
+    undo_commands.DeleteEntryCommand.redo,
+    undo_commands.AddVehicleCommand.undo,
+    undo_commands.AddVehicleCommand.redo,
+    undo_commands.DeleteVehicleCommand.undo,
+    undo_commands.DeleteVehicleCommand.redo,
+    undo_commands.UpdateVehicleCommand.undo,
+    undo_commands.UpdateVehicleCommand.redo,
 
-# --- Variables used by Pydantic ---
-settings.model_config
+    # --- Methods that might be used by UI or future features ---
+    exporter.monthly_excel,
+    importer.import_csv,
+    report_service.generate_report,
+    report_service.export_csv,
+    report_service.export_pdf,
+    report_service.export_excel,
+    storage_service.get_entries_by_vehicle,
+    storage_service.update_entry,
+
+    # --- Variables used by Pydantic ---
+    settings.model_config,
+)
+
+__all__ = ["_"]


### PR DESCRIPTION
## Summary
- update `.vulture-whitelist.py` to use valid imports

## Testing
- `ruff check .`
- `mypy src/ --strict` *(fails: BaseSettings and PySide6 stubs missing)*
- `vulture src .vulture-whitelist.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536c9640d08333895a43f629822378