### PR TITLE
Fix _load_prices slot connection

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -44,6 +44,7 @@ from PySide6.QtCore import (
     QSettings,
     QByteArray,
     QDate,
+    Slot,
 )
 from shiboken6 import isValid
 from concurrent.futures import ThreadPoolExecutor
@@ -1123,6 +1124,7 @@ class MainController(QObject):
         interval_ms = self.config.update_hours * 3_600_000
         QTimer.singleShot(interval_ms, self._schedule_price_update)
 
+    @Slot()
     def _load_prices(self) -> None:
         with Session(self.storage.engine) as session:
             rows = session.exec(


### PR DESCRIPTION
## Summary
- register `_load_prices` with Qt by importing Slot
- use `@Slot()` decorator so `invokeMethod` succeeds

## Testing
- `ruff check src/controllers/main_controller.py`
- `mypy src/ --strict` *(fails: missing stubs)*
- `vulture src .vulture-whitelist.py` *(fails: command not found)*
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685372a2f5c483339b566de7a27b6adc