### PR TITLE
Add metrics helper and load dialog function

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -100,6 +100,7 @@ from ..views import (
     AboutDialog,
     AddMaintenanceDialog,
     ImportCsvDialog,
+    load_add_entry_dialog,
 )
 from ..views.reports_page import ReportsPage
 from ..hotkey import GlobalHotkey
@@ -730,7 +731,8 @@ class MainController(QObject):
         if not self.storage.list_vehicles():
             QMessageBox.warning(self.window, "ไม่พบยานพาหนะ", "กรุณาเพิ่มยานพาหนะก่อน")
             return
-        dialog = AddEntryDialog(self.window)
+        dialog = load_add_entry_dialog()
+        dialog.setParent(self.window)
         today = date.today()
         dialog.dateEdit.setDate(QDate(today.year, today.month, today.day))
         dialog.odoBeforeEdit.setValidator(QDoubleValidator(0.0, 1e9, 2))

--- a/src/models/fuel_entry.py
+++ b/src/models/fuel_entry.py
@@ -20,3 +20,27 @@ class FuelEntry(SQLModel, table=True):
     amount_spent: Optional[float] = None
     #: Liters filled. Must be provided together with ``amount_spent``.
     liters: Optional[float] = None
+
+    def calc_metrics(self) -> dict[str, Optional[float]]:
+        """Return basic calculated metrics for this entry."""
+        distance = 0.0
+        if self.odo_after is not None:
+            distance = self.odo_after - self.odo_before
+
+        cost_per_km: Optional[float]
+        if distance > 0 and self.amount_spent is not None:
+            cost_per_km = self.amount_spent / distance
+        else:
+            cost_per_km = None
+
+        fuel_eff: Optional[float]
+        if self.liters and self.liters > 0 and distance > 0:
+            fuel_eff = distance / self.liters
+        else:
+            fuel_eff = None
+
+        return {
+            "distance": distance,
+            "cost_per_km": cost_per_km,
+            "fuel_efficiency_km_l": fuel_eff,
+        }


### PR DESCRIPTION
## Summary
- add `calc_metrics` to `FuelEntry`
- use `load_add_entry_dialog` helper when opening a new entry dialog

## Testing
- `pytest tests/test_models.py::test_calc_metrics_full -q`

------
https://chatgpt.com/codex/tasks/task_e_685374650e748333a5b6631b34c6896a