### PR TITLE
Fix Poe install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install -e .
 ติดตั้ง `Poe the Poet` เพื่อจัดการงานต่าง ๆ ภายในโปรเจ็กต์ได้ด้วย
 
 ```bash
-pip install poe-the-poet
+pip install poethepoet
 ```
 
 หรือใช้ตัวเลือกสำหรับนักพัฒนา


### PR DESCRIPTION
## Summary
- correct Poe the Poet package name in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685377e930a483338dc1fbd084c590eb