### PR TITLE
Fix app exit and Qt dock warnings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from PySide6.QtWidgets import QApplication, QMainWindow, QLabel
 
 def main() -> None:
@@ -7,7 +8,9 @@ def main() -> None:
     win.setCentralWidget(QLabel("Hello FuelTracker!"))
     win.resize(640, 480)
     win.show()
-    app.exec()
+    # CHANGED: exit cleanly with sys.exit
+    import sys
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
     main()

--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -113,6 +113,8 @@ class StatsDock(QDockWidget):
 
     def __init__(self, parent: QMainWindow | None = None) -> None:
         super().__init__("สถิติ", parent)
+        # ADDED: ensure unique object name for saveState
+        self.setObjectName("statsDock")
         self.kml_label = QLabel("km/L: -")
         self.cost_label = QLabel("฿/km: -")
         widget = QWidget()
@@ -127,6 +129,8 @@ class MaintenanceDock(QDockWidget):
 
     def __init__(self, parent: QMainWindow | None = None) -> None:
         super().__init__("บำรุงรักษา", parent)
+        # ADDED: ensure unique object name for saveState
+        self.setObjectName("maintenanceDock")
         self.list_widget = QListWidget()
         self.add_button = QPushButton("เพิ่ม")
         self.edit_button = QPushButton("แก้ไข")
@@ -147,6 +151,8 @@ class OilPricesDock(QDockWidget):
 
     def __init__(self, parent: QMainWindow | None = None) -> None:
         super().__init__("ราคาน้ำมัน", parent)
+        # ADDED: ensure unique object name for saveState
+        self.setObjectName("oilPricesDock")
         self.table = QTableWidget(0, 3)
         self.table.setHorizontalHeaderLabels(["วันที่", "ประเภทเชื้อเพลิง", "ราคา"])
         self.figure = Figure(figsize=(4, 3))


### PR DESCRIPTION
## Summary
- exit with `sys.exit(app.exec())`
- set unique object names on dock widgets so Qt can save state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named '...' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6853a2cc28048333951925598e7587b7