### PR TITLE
Fix application shutdown sequence

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,15 @@
-from pathlib import Path
+# ADDED: import sys for proper exit handling
+import sys
 from PySide6.QtWidgets import QApplication, QMainWindow, QLabel
 
 def main() -> None:
-    app = QApplication([])
+    app = QApplication(sys.argv[:1])
     win = QMainWindow()
     win.setWindowTitle("FuelTracker (stub)")
     win.setCentralWidget(QLabel("Hello FuelTracker!"))
     win.resize(640, 480)
     win.show()
     # CHANGED: exit cleanly with sys.exit
-    import sys
     sys.exit(app.exec())
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- call `sys.exit(app.exec())` inside `main`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6853aa10bb4483339c59ffae8648872c