### PR TITLE
Fix GUI teardown in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,4 +81,5 @@ def main_controller(qapp, migrated_db_session, monkeypatch):
 
     ctrl = MainController()
     yield ctrl
+    ctrl.window.close()  # ADDED: ensure Qt window cleanup
     ctrl.cleanup()


### PR DESCRIPTION
## Summary
- close the main window in `main_controller` fixture to avoid PyQt teardown issues

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, AssertionError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6853ac9e38988333883abe33aadd31ba