### PR TITLE
Fix hotkey callback signature

### DIFF
--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -26,7 +26,7 @@ class GlobalHotkey(QObject):
         # backend fires callbacks as we are tearing down.
         self._stopping = False
 
-    def _wrapped_callback(self) -> int:
+    def _wrapped_callback(self, *args: object) -> int:
         """Emit the hotkey signal and return ``1`` for Win32 hooks."""
         if self._stopping:
             # Ignore callbacks that may fire while the listener is shutting down


### PR DESCRIPTION
## Summary
- fix the signature for `_wrapped_callback` so unexpected args don't break hotkeys

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6853bfc770c48333beaacbc7527aab54