### PR TITLE
Fix test execution by documenting libegl1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@
 python -m venv .venv
 pip install -r requirements.txt
 pip install -e .
+# หากรันบน Linux (Debian/Ubuntu) ติดตั้งไลบรารีนี้เพื่อให้การทดสอบ PySide6 ทำงานได้
+sudo apt-get install -y libegl1
+# หากรันบน Windows ไม่ต้องติดตั้งแพ็กเกจเสริม
 ```
 
 ## Using Poe the Poet


### PR DESCRIPTION
## Summary
- document `libegl1` system package requirement for running Qt tests
- clarify that Windows users do not need this package

## Testing
- `pytest tests/test_preferences.py::test_controller_reads_preferences -vv`
- `pytest -q` *(fails: tests/test_entrypoints_launch.py::test_entrypoints_launch)*

------
https://chatgpt.com/codex/tasks/task_e_6853b6027bb08333a90438d83c2231e3