### PR TITLE
Fix hotkey cleanup

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -1223,6 +1223,13 @@ class MainController(QObject):
         self._unregister_hotkey()
         self.executor.shutdown(wait=False)
 
+    def __del__(self) -> None:  # pragma: no cover - defensive
+        """Ensure resources are released if cleanup was not called."""
+        try:
+            self.cleanup()
+        except Exception:
+            pass
+
     def shutdown(self) -> None:
         backup = self.storage.auto_backup()
         if self.sync_enabled and self.cloud_path is not None:

--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -81,6 +81,14 @@ class GlobalHotkey(QObject):
             self._registered = False
             self._stopping = False
 
+    def __del__(self) -> None:  # pragma: no cover - defensive
+        """Ensure any system hooks are released on object deletion."""
+        try:
+            self.stop()
+        except Exception:
+            # Avoid spurious errors during interpreter shutdown
+            pass
+
     @staticmethod
     def _format(seq: str) -> str:
         """Normalize Qt style hotkey string to keyboard module format."""


### PR DESCRIPTION
## Summary
- release system hotkey hooks on object deletion
- ensure MainController performs cleanup when garbage-collected

## Testing
- `pytest tests/test_preferences.py -q`
- `pytest tests/test_hotkey.py -q`
- `pytest tests/test_ui_smoke.py::test_cleanup_unregisters_hotkey -q`


------
https://chatgpt.com/codex/tasks/task_e_6853c1ddb9448333ba628bda160af00d