### PR TITLE
Fix WPARAM callback docs

### DIFF
--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -28,6 +28,9 @@ class GlobalHotkey(QObject):
 
     def _callback_adapter(self, *args: object) -> int:
         """Invoke ``_wrapped_callback`` and always return ``1`` for Win32 hooks."""
+        # Qt expects a Win32 hook callback to return an ``int``. If ``None`` is
+        # returned, a ``TypeError`` like ``WPARAM is simple, so must be an int``
+        # is raised during event dispatch. Always returning ``1`` avoids this.
         try:
             self._wrapped_callback(*args)
         except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- document WPARAM workaround in hotkey adapter

## Testing
- `pytest -q tests/test_hotkey.py::test_hotkey_returns_int -vv`

------
https://chatgpt.com/codex/tasks/task_e_6853fcb4650883339663227d2e174bdb