### PR TITLE
Fix WPARAM error test coverage

### DIFF
--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -70,3 +70,12 @@ def test_hotkey_returns_int(monkeypatch):
     called.clear()
     assert gh._wrapped_callback() == 1
     assert called == [True]
+
+
+def test_hotkey_adapter_handles_exception(monkeypatch):
+    gh = GlobalHotkey("Ctrl+Shift+N")
+    def boom(*args: object) -> int:
+        raise RuntimeError("fail")
+    monkeypatch.setattr(gh, "_wrapped_callback", boom)
+    # Should return 1 even if the wrapped callback raises an error
+    assert gh._callback_adapter() == 1


### PR DESCRIPTION
## Summary
- add regression test for hotkey adapter exception path

## Testing
- `pytest tests/test_hotkey.py::test_hotkey_adapter_handles_exception -q`
- `pytest -q` *(fails: test_entrypoints_launch)*

------
https://chatgpt.com/codex/tasks/task_e_6854005f7ae88333af81c5517cc01b23