### PR TITLE
Fix unused import

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -95,7 +95,6 @@ from .undo_commands import (
 )
 from ..views import (
     MainWindow,
-    AddEntryDialog,
     AddVehicleDialog,
     AboutDialog,
     AddMaintenanceDialog,


### PR DESCRIPTION
## Summary
- remove unused `AddEntryDialog` import in main controller

## Testing
- `ruff check src/controllers/main_controller.py`
- `mypy src/ --strict` *(fails: missing dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_68540586897c8333a18ab05c23600d9a