### PR TITLE
Fix add-entry dialog typing

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -100,6 +100,7 @@ from ..views import (
     AddMaintenanceDialog,
     ImportCsvDialog,
     load_add_entry_dialog,
+    AddEntryDialog,
 )
 from ..views.reports_page import ReportsPage
 from ..hotkey import GlobalHotkey
@@ -740,7 +741,7 @@ class MainController(QObject):
         if not self.storage.list_vehicles():
             QMessageBox.warning(self.window, "ไม่พบยานพาหนะ", "กรุณาเพิ่มยานพาหนะก่อน")
             return
-        dialog = load_add_entry_dialog()
+        dialog = cast(AddEntryDialog, load_add_entry_dialog())
         dialog.setParent(self.window)
         dialog.buttonBox.accepted.connect(dialog.accept)
         dialog.buttonBox.rejected.connect(dialog.reject)


### PR DESCRIPTION
## Summary
- import `AddEntryDialog` in main controller
- cast loaded add-entry dialog to `AddEntryDialog` so attributes are recognized

## Testing
- `poetry run mypy src/ --strict` *(fails: BaseSettings, SQLModel, requests, etc.)*
- `poetry run poe test` *(fails: ImportError: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685408e7fc548333a9b9b5fff0e0df8b