### PR TITLE
Fix mypy attr-defined errors for dialog helpers

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -156,7 +156,7 @@ class OilPricesDock(QDockWidget):
         self.table.setHorizontalHeaderLabels(["วันที่", "ประเภทเชื้อเพลิง", "ราคา"])
         self.figure = Figure(figsize=(4, 3))
         # ``FigureCanvasQTAgg`` comes from ``matplotlib`` which is not fully typed
-        self.canvas = FigureCanvasQTAgg(self.figure)
+        self.canvas = FigureCanvasQTAgg(self.figure)  # type: ignore[no-untyped-call]
         widget = QWidget()
         layout = QVBoxLayout(widget)
         layout.addWidget(self.table)

--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -64,29 +64,29 @@ def load_ui(name: str) -> QWidget:
     return widget
 
 
-def load_add_entry_dialog() -> QDialog:
+def load_add_entry_dialog() -> AddEntryDialog:
     """ตัวช่วยโหลดกล่องโต้ตอบเพิ่มข้อมูลการเติมน้ำมัน"""
-    return cast(QDialog, load_ui("dialogs/add_entry_dialog"))
+    return cast(AddEntryDialog, load_ui("dialogs/add_entry_dialog"))
 
 
-def load_add_vehicle_dialog() -> QDialog:
+def load_add_vehicle_dialog() -> AddVehicleDialog:
     """ตัวช่วยโหลดกล่องโต้ตอบเพิ่มยานพาหนะ"""
-    return cast(QDialog, load_ui("dialogs/add_vehicle_dialog"))
+    return cast(AddVehicleDialog, load_ui("dialogs/add_vehicle_dialog"))
 
 
-def load_about_dialog() -> QDialog:
+def load_about_dialog() -> AboutDialog:
     """ตัวช่วยโหลดกล่องโต้ตอบเกี่ยวกับโปรแกรม"""
-    return cast(QDialog, load_ui("dialogs/about_dialog"))
+    return cast(AboutDialog, load_ui("dialogs/about_dialog"))
 
 
-def load_add_maintenance_dialog() -> QDialog:
+def load_add_maintenance_dialog() -> AddMaintenanceDialog:
     """ตัวช่วยโหลดกล่องโต้ตอบเพิ่มงานบำรุงรักษา"""
-    return cast(QDialog, load_ui("dialogs/add_maintenance_dialog"))
+    return cast(AddMaintenanceDialog, load_ui("dialogs/add_maintenance_dialog"))
 
 
-def load_import_csv_dialog() -> QDialog:
+def load_import_csv_dialog() -> ImportCsvDialog:
     """ตัวช่วยโหลดกล่องโต้ตอบนำเข้าข้อมูลจาก CSV"""
-    return cast(QDialog, load_ui("dialogs/import_csv_dialog"))
+    return cast(ImportCsvDialog, load_ui("dialogs/import_csv_dialog"))
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- update dialog loader helpers to return their concrete classes
- silence untyped matplotlib canvas call

## Testing
- `mypy src/ --strict`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685408e7fc548333a9b9b5fff0e0df8b