### PR TITLE
Fix AddEntryDialog typing

### DIFF
--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -64,9 +64,9 @@ def load_ui(name: str) -> QWidget:
     return widget
 
 
-def load_add_entry_dialog() -> QDialog:
+def load_add_entry_dialog() -> AddEntryDialog:
     """ตัวช่วยโหลดกล่องโต้ตอบเพิ่มข้อมูลการเติมน้ำมัน"""
-    return cast(QDialog, load_ui("dialogs/add_entry_dialog"))
+    return AddEntryDialog()
 
 
 def load_add_vehicle_dialog() -> QDialog:


### PR DESCRIPTION
## Summary
- return AddEntryDialog from loader to keep attributes typed

## Testing
- `poetry run mypy src/controllers/main_controller.py --strict | head -n 20`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_685408e7fc548333a9b9b5fff0e0df8b