### PR TITLE
Fix dialog acceptance and entrypoint

### DIFF
--- a/fueltracker.egg-info/PKG-INFO
+++ b/fueltracker.egg-info/PKG-INFO
@@ -1,0 +1,4 @@
+Metadata-Version: 2.1
+Name: fueltracker
+Version: 0.1.0
+Summary: Fuel tracker sample application

--- a/fueltracker.egg-info/entry_points.txt
+++ b/fueltracker.egg-info/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+fueltracker = fueltracker.main:run

--- a/fueltracker.egg-info/top_level.txt
+++ b/fueltracker.egg-info/top_level.txt
@@ -1,0 +1,1 @@
+fueltracker

--- a/fueltracker/__init__.py
+++ b/fueltracker/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for running as a top-level package."""
+from importlib import import_module
+import sys
+_module = import_module('src.fueltracker')
+sys.modules[__name__] = _module

--- a/fueltracker/__main__.py
+++ b/fueltracker/__main__.py
@@ -1,0 +1,4 @@
+from src.fueltracker.__main__ import run
+
+if __name__ == '__main__':
+    run()

--- a/src/views/dialogs/about_dialog.py
+++ b/src/views/dialogs/about_dialog.py
@@ -7,3 +7,6 @@ class AboutDialog(QDialog, Ui_AboutDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         cast(Callable[[QDialog], None], self.setupUi)(self)
+        if hasattr(self, "buttonBox"):
+            self.buttonBox.accepted.connect(self.accept)
+            self.buttonBox.rejected.connect(self.reject)

--- a/src/views/dialogs/add_vehicle_dialog.py
+++ b/src/views/dialogs/add_vehicle_dialog.py
@@ -7,3 +7,7 @@ class AddVehicleDialog(QDialog, Ui_AddVehicleDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         cast(Callable[[QDialog], None], self.setupUi)(self)
+        # ensure standard dialog buttons behave as expected
+        if hasattr(self, "buttonBox"):
+            self.buttonBox.accepted.connect(self.accept)
+            self.buttonBox.rejected.connect(self.reject)


### PR DESCRIPTION
## Summary
- hook up button box signals in dialogs
- create top-level `fueltracker` package and minimal egg-info so console entrypoint works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540b6b9c5c8333843861109acb908a