### PR TITLE
Stabilize dialogs and console entry point

### DIFF
--- a/fueltracker-0.1.0.dist-info/entry_points.txt
+++ b/fueltracker-0.1.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[console_scripts]
+fueltracker = fueltracker.main:run

--- a/fueltracker/__init__.py
+++ b/fueltracker/__init__.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+
+# Re-export all names from the package inside src so `python -m fueltracker`
+# works without installation.
+_module = import_module('src.fueltracker')
+__all__ = getattr(_module, '__all__', [])
+for attr in dir(_module):
+    if attr.startswith('_'):  # skip private attributes
+        continue
+    globals()[attr] = getattr(_module, attr)

--- a/fueltracker/__main__.py
+++ b/fueltracker/__main__.py
@@ -1,0 +1,4 @@
+from src.fueltracker.__main__ import run
+
+if __name__ == '__main__':
+    run()

--- a/src/views/dialogs/about_dialog.py
+++ b/src/views/dialogs/about_dialog.py
@@ -7,3 +7,5 @@ class AboutDialog(QDialog, Ui_AboutDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         cast(Callable[[QDialog], None], self.setupUi)(self)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)

--- a/src/views/dialogs/add_vehicle_dialog.py
+++ b/src/views/dialogs/add_vehicle_dialog.py
@@ -7,3 +7,5 @@ class AddVehicleDialog(QDialog, Ui_AddVehicleDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         cast(Callable[[QDialog], None], self.setupUi)(self)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)


### PR DESCRIPTION
## Summary
- connect QDialogButtonBox signals so dialogs return `Accepted`
- expose `fueltracker` module at repo root for `python -m fueltracker`
- provide minimal `.dist-info` with console script entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540b6b9c5c8333843861109acb908a