### PR TITLE
Ensure dialog buttons close dialogs

### DIFF
--- a/src/views/dialogs/about_dialog.py
+++ b/src/views/dialogs/about_dialog.py
@@ -7,3 +7,6 @@ class AboutDialog(QDialog, Ui_AboutDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         cast(Callable[[QDialog], None], self.setupUi)(self)
+        # Hook up dialog buttons to standard accept/reject slots
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)

--- a/src/views/dialogs/add_vehicle_dialog.py
+++ b/src/views/dialogs/add_vehicle_dialog.py
@@ -7,3 +7,7 @@ class AddVehicleDialog(QDialog, Ui_AddVehicleDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         cast(Callable[[QDialog], None], self.setupUi)(self)
+        # Ensure the dialog behaves like a standard dialog by
+        # closing with an accepted result when the OK button is clicked
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)


### PR DESCRIPTION
## Summary
- connect AddVehicleDialog and AboutDialog buttons to accept/reject
- all tests now pass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68540b6b9c5c8333843861109acb908a