### PR TITLE
Refactor system tray into TrayIconManager

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -7,6 +7,7 @@ from .importer import Importer
 from .charts import monthly_summary
 from .oil_service import fetch_latest, get_price
 from .theme_manager import ThemeManager
+from .tray_icon_manager import TrayIconManager
 
 __all__ = [
     "ReportService",
@@ -17,4 +18,5 @@ __all__ = [
     "fetch_latest",
     "get_price",
     "ThemeManager",
+    "TrayIconManager",
 ]

--- a/src/services/tray_icon_manager.py
+++ b/src/services/tray_icon_manager.py
@@ -1,0 +1,72 @@
+"""Manage the application's system tray icon and menu."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from PySide6.QtWidgets import QSystemTrayIcon, QMenu, QWidget
+from PySide6.QtGui import QAction, QIcon
+from PySide6.QtCore import QObject
+
+
+class TrayIconManager(QObject):
+    """Handle creation and interaction of the system tray icon."""
+
+    def __init__(
+        self,
+        parent: QWidget | None,
+        show_action: Callable[[], None],
+        hide_action: Callable[[], None],
+        add_entry_action: Callable[[], None],
+        quit_action: Callable[[], None],
+    ) -> None:
+        super().__init__(parent)
+        self._show_action = show_action
+        self._hide_action = hide_action
+        self._add_entry_action = add_entry_action
+        self._quit_action = quit_action
+
+        icon = QIcon("icons:home.svg")
+        self.tray_icon = QSystemTrayIcon(icon, parent)
+
+        menu = QMenu(parent)
+        add_act = QAction("เพิ่มรายการใหม่", parent)
+        add_act.triggered.connect(self._add_entry_action)
+        menu.addAction(add_act)
+
+        show_act = QAction("เปิดหน้าต่างหลัก", parent)
+        show_act.triggered.connect(self._show_action)
+        menu.addAction(show_act)
+
+        quit_act = QAction("ออก", parent)
+        quit_act.triggered.connect(self._quit_action)
+        menu.addAction(quit_act)
+
+        self.tray_icon.setContextMenu(menu)
+        self.tray_icon.activated.connect(self._on_activated)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def show(self) -> None:
+        self.tray_icon.show()
+
+    def hide(self) -> None:
+        self.tray_icon.hide()
+
+    def is_visible(self) -> bool:
+        return self.tray_icon.isVisible()
+
+    def set_tooltip(self, text: str) -> None:
+        self.tray_icon.setToolTip(text)
+
+    def show_message(self, title: str, message: str, msecs: int = 10000) -> None:
+        self.tray_icon.showMessage(title, message, QSystemTrayIcon.MessageIcon.NoIcon, msecs)
+
+    # ------------------------------------------------------------------
+    # Internal callbacks
+    # ------------------------------------------------------------------
+    def _on_activated(self, reason: QSystemTrayIcon.ActivationReason) -> None:
+        if reason == QSystemTrayIcon.ActivationReason.Trigger:
+            self._show_action()
+


### PR DESCRIPTION
## Summary
- add `TrayIconManager` service for building the tray icon and menu
- expose new manager from the services package
- use `TrayIconManager` in `MainController`
- remove old tray icon methods and references

## Testing
- `ruff check src/services/tray_icon_manager.py src/controllers/main_controller.py src/services/__init__.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68541c75337883339e4e8b4c3eb15efc