### PR TITLE
Fix dev dependency typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
 
     # Type Stubs
     "types-requests",
-    "types-matplotlib",
     "types-keyboard",
     "types-reportlab",
     "matplotlib-stubs",


### PR DESCRIPTION
## Summary
- remove `types-matplotlib` from the dev requirements

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68542197c22c83338b55a8de7db49f0b