### PR TITLE
Refactor fill workflow

### DIFF
--- a/src/services/validators.py
+++ b/src/services/validators.py
@@ -7,5 +7,8 @@ def validate_entry(entry: FuelEntry) -> None:
     """ตรวจสอบ :class:`FuelEntry` ก่อนบันทึก"""
     if entry.odo_after is not None and entry.odo_after < entry.odo_before:
         raise ValueError("odo_after must be >= odo_before")
-    if (entry.amount_spent is None) != (entry.liters is None):
-        raise ValueError("amount_spent and liters must be given together or neither")
+    # ``liters`` cannot be stored without a corresponding ``amount_spent`` value.
+    # When adding a new refuel entry the liters are calculated later, so
+    # ``amount_spent`` may be provided without ``liters``.
+    if entry.liters is not None and entry.amount_spent is None:
+        raise ValueError("amount_spent must be given with liters")

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -128,7 +128,7 @@ def test_prefill_odometer(main_controller, monkeypatch):
 
     def fake_exec():
         assert float(dialog.odoBeforeEdit.text()) == 500.0
-        assert float(dialog.odoAfterEdit.text()) == 500.0
+        assert not dialog.odoAfterEdit.isEnabled()
         return QDialog.Rejected
 
     monkeypatch.setattr(dialog, "exec", fake_exec)

--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -76,14 +76,13 @@ def test_autofill_liters(main_controller, monkeypatch):
     )
 
     def fake_exec():
-        dialog.amountEdit.setText("100")
-        dialog.amountEdit.editingFinished.emit()
         return QDialog.Rejected
 
     monkeypatch.setattr(dialog, "exec", fake_exec)
 
     ctrl.open_add_entry_dialog()
-    assert dialog.litersEdit.text() == "2.00"
+    assert not dialog.litersEdit.isEnabled()
+    assert not dialog.odoAfterEdit.isEnabled()
 
 
 def test_price_update_handles_error(main_controller, monkeypatch):

--- a/tests/test_refuel_flow.py
+++ b/tests/test_refuel_flow.py
@@ -1,0 +1,56 @@
+from datetime import date
+from decimal import Decimal
+
+from sqlmodel import Session
+import pytest
+
+from src.models import FuelEntry, Vehicle, FuelPrice
+from src.services import StorageService
+
+
+def test_first_fill(in_memory_storage: StorageService) -> None:
+    storage = in_memory_storage
+    vehicle = Vehicle(name="Car", vehicle_type="t", license_plate="x", tank_capacity_liters=40)
+    storage.add_vehicle(vehicle)
+    entry = FuelEntry(entry_date=date(2024, 1, 1), vehicle_id=vehicle.id, odo_before=1000.0, amount_spent=800.0)
+    storage.add_entry(entry)
+    fetched = storage.get_entry(entry.id)
+    assert fetched.odo_after is None
+    assert fetched.liters is None
+
+
+def test_normal_flow_completes_previous(in_memory_storage: StorageService) -> None:
+    storage = in_memory_storage
+    vehicle = Vehicle(name="Car", vehicle_type="t", license_plate="x", tank_capacity_liters=40)
+    storage.add_vehicle(vehicle)
+
+    with Session(storage.engine) as s:
+        s.add(FuelPrice(date=date(2024, 1, 1), station="ptt", fuel_type="e20", name_th="E20", price=Decimal("40")))
+        s.commit()
+
+    first = FuelEntry(entry_date=date(2024, 1, 1), vehicle_id=vehicle.id, fuel_type="e20", odo_before=1000.0, amount_spent=800.0)
+    storage.add_entry(first)
+    second = FuelEntry(entry_date=date(2024, 1, 5), vehicle_id=vehicle.id, fuel_type="e20", odo_before=1100.0, amount_spent=600.0)
+    storage.add_entry(second)
+
+    updated = storage.get_entry(first.id)
+    assert updated.odo_after == 1100.0
+    assert updated.liters == pytest.approx(20.0)
+    metrics = updated.calc_metrics()
+    assert metrics["distance"] == pytest.approx(100.0)
+    assert metrics["fuel_efficiency_km_l"] == pytest.approx(5.0)
+
+
+def test_missing_price_keeps_liters_none(in_memory_storage: StorageService) -> None:
+    storage = in_memory_storage
+    vehicle = Vehicle(name="Car", vehicle_type="t", license_plate="x", tank_capacity_liters=40)
+    storage.add_vehicle(vehicle)
+
+    first = FuelEntry(entry_date=date(2024, 1, 1), vehicle_id=vehicle.id, fuel_type="e20", odo_before=1000.0, amount_spent=800.0)
+    storage.add_entry(first)
+    second = FuelEntry(entry_date=date(2024, 1, 3), vehicle_id=vehicle.id, fuel_type="e20", odo_before=1100.0, amount_spent=500.0)
+    storage.add_entry(second)
+
+    updated = storage.get_entry(first.id)
+    assert updated.odo_after == 1100.0
+    assert updated.liters is None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,7 +21,7 @@ def test_invalid_odometer(tmp_path):
         storage.add_entry(entry)
 
 
-def test_incomplete_pair(tmp_path):
+def test_liters_requires_amount(tmp_path):
     storage = StorageService(db_path=tmp_path / "fuel.db")
     storage.add_vehicle(
         Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
@@ -31,8 +31,8 @@ def test_incomplete_pair(tmp_path):
         vehicle_id=1,
         odo_before=0.0,
         odo_after=50.0,
-        amount_spent=20.0,
-        liters=None,
+        amount_spent=None,
+        liters=5.0,
     )
     with pytest.raises(ValueError):
         storage.add_entry(entry)


### PR DESCRIPTION
## Summary
- update validation to allow pending litres
- compute previous fill metrics when adding a new entry
- disable odometer-after and litres fields in the add-entry dialog
- adjust tests and add new tests for the new flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542d715a448333ae656122fca758b6