### PR TITLE
Improve monthly export filtering

### DIFF
--- a/src/services/exporter.py
+++ b/src/services/exporter.py
@@ -15,12 +15,7 @@ class Exporter:
         self.storage = storage
 
     def _entries(self, month: int, year: int) -> List[FuelEntry]:
-        entries = self.storage.list_entries()
-        return [
-            e
-            for e in entries
-            if e.entry_date.year == year and e.entry_date.month == month
-        ]
+        return self.storage.list_entries_for_month(year, month)
 
     def monthly_csv(self, month: int, year: int, path: Path) -> None:
         entries = self._entries(month, year)

--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -57,7 +57,7 @@ class ReportService:
 
     def _filter_entries(self, month: date, vehicle_id: int) -> List[FuelEntry]:
         """ดึงรายการของยานพาหนะในเดือนที่กำหนด"""
-        return self.storage.list_entries_for_month(vehicle_id, month.year, month.month)
+        return self.storage.list_entries_for_month(month.year, month.month, vehicle_id)
 
     # FIX: mypy clean
     def _monthly_df(self, month: date, vehicle_id: int) -> DataFrame:

--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -284,16 +284,17 @@ class StorageService:
             )
 
     def list_entries_for_month(
-        self, vehicle_id: int, year: int, month: int
+        self, year: int, month: int, vehicle_id: int | None = None
     ) -> List[FuelEntry]:
-        """Return entries for a vehicle within the given month."""
+        """Return entries within the given month optionally filtered by vehicle."""
         with Session(self.engine) as session:
             stmt = select(FuelEntry).where(
-                FuelEntry.vehicle_id == vehicle_id,
                 cast(Any, FuelEntry.entry_date).between(
                     f"{year}-{month:02d}-01", f"{year}-{month:02d}-31"
-                ),
+                )
             )
+            if vehicle_id is not None:
+                stmt = stmt.where(FuelEntry.vehicle_id == vehicle_id)
             return list(session.exec(stmt))
 
     def monthly_totals(self) -> list[tuple[str, float, float, float]]:


### PR DESCRIPTION
## Summary
- use new StorageService filtering in exporter
- add optional vehicle filter to StorageService.list_entries_for_month
- update ReportService for changed method signature

## Testing
- `pytest tests/test_reports.py::test_export_csv -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68551c939be083338184790eff643e21