### PR TITLE
Add fuelprice index migration

### DIFF
--- a/alembic/versions/0007_add_fuelprice_index.py
+++ b/alembic/versions/0007_add_fuelprice_index.py
@@ -1,0 +1,23 @@
+"""add index on fuelprice(date, station, fuel_type)"""
+
+from alembic import op
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_fuelprice_date_station_fuel_type",
+        "fuelprice",
+        ["date", "station", "fuel_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_fuelprice_date_station_fuel_type",
+        table_name="fuelprice",
+    )

--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -86,7 +86,7 @@ from ..services import (
     ThemeManager,
     TrayIconManager,
 )
-from ..services.oil_service import fetch_latest
+from ..services.oil_service import fetch_latest, get_price as _get_price
 from ..config import AppConfig
 from .undo_commands import (
     AddEntryCommand,
@@ -107,6 +107,11 @@ from ..views.reports_page import ReportsPage
 from ..hotkey import GlobalHotkey
 
 DEFAULT_FUEL_TYPE = "e20"
+
+
+def get_price(*args, **kwargs):
+    """Wrapper to access :func:`src.services.oil_service.get_price`."""
+    return _get_price(*args, **kwargs)
 
 
 class StatsDock(QDockWidget):

--- a/src/models/fuel_price.py
+++ b/src/models/fuel_price.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Optional
 
 from sqlmodel import Field, SQLModel
+from sqlalchemy import Index
 
 
 class FuelPrice(SQLModel, table=True):
@@ -16,3 +17,12 @@ class FuelPrice(SQLModel, table=True):
     fuel_type: str
     name_th: str
     price: Decimal
+
+    __table_args__ = (
+        Index(
+            "ix_fuelprice_date_station_fuel_type",
+            "date",
+            "station",
+            "fuel_type",
+        ),
+    )

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -25,6 +25,8 @@ def test_indexes_created(engine: Engine) -> None:
     insp = sqlalchemy.inspect(engine)
     fuel_indexes = {idx["name"] for idx in insp.get_indexes("fuelentry")}
     maint_indexes = {idx["name"] for idx in insp.get_indexes("maintenance")}
+    price_indexes = {idx["name"] for idx in insp.get_indexes("fuelprice")}
     assert "ix_fuelentry_vehicle_id" in fuel_indexes
     assert "ix_fuelentry_entry_date" in fuel_indexes
     assert "ix_maintenance_vehicle_id" in maint_indexes
+    assert "ix_fuelprice_date_station_fuel_type" in price_indexes


### PR DESCRIPTION
## Summary
- add index definition to `FuelPrice` model
- create Alembic migration to add the new index
- test the new index in `test_migration`
- expose `get_price` in `MainController` for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551ff7df8c8333a9b0c77092c70598