### PR TITLE
Improve auto_backup with SQLite backup method

### DIFF
--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -500,7 +500,13 @@ class StorageService:
         backup_dir.mkdir(parents=True, exist_ok=True)
 
         backup_path = backup_dir / now.strftime("%y-%m-%d_%H%M.db")
-        shutil.copy2(self._db_path, backup_path)
+
+        source_conn = self.engine.raw_connection()
+        try:
+            with sqlcipher.connect(str(backup_path)) as dest_conn:
+                source_conn.backup(dest_conn)
+        finally:
+            source_conn.close()
 
         backups = [p for p in backup_dir.glob("*.db") if p != self._db_path]
         backups.sort()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from src.services import StorageService
+import sqlite3
 from src.models import Vehicle
 
 
@@ -12,7 +13,11 @@ def test_backup_rotation(tmp_path):
     )
     now = datetime(2024, 1, 1, 0, 0)
     for i in range(35):
-        storage.auto_backup(now=now + timedelta(minutes=i), backup_dir=tmp_path)
+        backup = storage.auto_backup(now=now + timedelta(minutes=i), backup_dir=tmp_path)
+        if i == 0:
+            with sqlite3.connect(backup) as conn:
+                conn.execute("SELECT name FROM sqlite_master").fetchall()
+            backup.unlink()
     backups = sorted(p for p in tmp_path.glob("*.db") if p.name != "fuel.db")
     assert len(backups) == 30
     first = backups[0].stem


### PR DESCRIPTION
## Summary
- refactor StorageService.auto_backup to use sqlite backup API instead of `shutil.copy2`
- ensure the new backup file is closed via context manager
- test that backup rotation still works and backup files can be opened

## Testing
- `pytest tests/test_backup.py::test_backup_rotation -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552e5ef31483338cd7dc0176e5f1b1