### PR TITLE
Define indexes in models and validate in tests

### DIFF
--- a/src/models/fuel_entry.py
+++ b/src/models/fuel_entry.py
@@ -4,6 +4,7 @@ from datetime import date
 from typing import Optional
 
 from sqlmodel import Field, SQLModel
+from sqlalchemy import Index
 
 
 class FuelEntry(SQLModel, table=True):
@@ -20,6 +21,11 @@ class FuelEntry(SQLModel, table=True):
     amount_spent: Optional[float] = None
     #: Liters filled. Must be provided together with ``amount_spent``.
     liters: Optional[float] = None
+
+    __table_args__ = (
+        Index("ix_fuelentry_vehicle_id", "vehicle_id"),
+        Index("ix_fuelentry_entry_date", "entry_date"),
+    )
 
     def calc_metrics(self) -> dict[str, Optional[float]]:
         """Return basic calculated metrics for this entry."""

--- a/src/models/maintenance.py
+++ b/src/models/maintenance.py
@@ -4,6 +4,7 @@ from datetime import date
 from typing import Optional
 
 from sqlmodel import Field, SQLModel
+from sqlalchemy import Index
 
 
 class Maintenance(SQLModel, table=True):
@@ -16,3 +17,7 @@ class Maintenance(SQLModel, table=True):
     due_date: Optional[date] = None
     note: Optional[str] = None
     is_done: bool = False
+
+    __table_args__ = (
+        Index("ix_maintenance_vehicle_id", "vehicle_id"),
+    )

--- a/tests/test_inmemory_indexes.py
+++ b/tests/test_inmemory_indexes.py
@@ -1,0 +1,14 @@
+import sqlalchemy
+from src.services import StorageService
+
+
+def test_indexes_created_in_memory(in_memory_storage: StorageService) -> None:
+    engine = in_memory_storage.engine
+    insp = sqlalchemy.inspect(engine)
+    fuel_indexes = {idx["name"] for idx in insp.get_indexes("fuelentry")}
+    maint_indexes = {idx["name"] for idx in insp.get_indexes("maintenance")}
+    price_indexes = {idx["name"] for idx in insp.get_indexes("fuelprice")}
+    assert "ix_fuelentry_vehicle_id" in fuel_indexes
+    assert "ix_fuelentry_entry_date" in fuel_indexes
+    assert "ix_maintenance_vehicle_id" in maint_indexes
+    assert "ix_fuelprice_date_station_fuel_type" in price_indexes


### PR DESCRIPTION
## Summary
- define DB indexes directly in `FuelEntry` and `Maintenance` models
- test for index creation when using an in-memory DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855451011b883338aade426ab8645b4