### PR TITLE
Switch report generation to logging

### DIFF
--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -12,6 +12,7 @@ import pandas as pd
 from fpdf import FPDF
 import matplotlib
 from io import BytesIO
+import logging
 
 # Use a non-interactive backend for headless environments
 matplotlib.use("Agg")
@@ -22,6 +23,8 @@ from typing import Callable, cast
 from ..models import FuelEntry, Vehicle
 from .storage_service import StorageService
 from ..constants import FUEL_TYPE_TH
+
+logger = logging.getLogger(__name__)
 
 date2num = cast(Callable[[date], float], mdates.date2num)
 
@@ -48,9 +51,9 @@ class ReportService:
 
     def generate_report(self) -> None:
         stats = self.calc_overall_stats()
-        print("Generated report:")
+        logger.info("Generated report:")
         for key, value in stats.items():
-            print(f"{key}: {value}")
+            logger.info("%s: %s", key, value)
 
     # ------------------------------------------------------------------
     # New functionality for exporting monthly reports

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+import logging
 import pytest
 from src.models import FuelEntry
 from src.services import ReportService
@@ -48,7 +49,7 @@ def test_calc_overall_stats(in_memory_storage):
     assert stats["cost_per_km"] == pytest.approx(60.0 / 300.0)
 
 
-def test_generate_report_output(capsys, in_memory_storage):
+def test_generate_report_output(caplog, in_memory_storage):
     storage = in_memory_storage
     storage.add_entry(
         FuelEntry(
@@ -61,10 +62,10 @@ def test_generate_report_output(capsys, in_memory_storage):
         )
     )
     service = ReportService(storage)
-    service.generate_report()
-    captured = capsys.readouterr()
-    assert "total_distance" in captured.out
-    assert "avg_consumption" in captured.out
+    with caplog.at_level(logging.INFO):
+        service.generate_report()
+    assert "total_distance" in caplog.text
+    assert "avg_consumption" in caplog.text
 
 
 def test_get_monthly_stats(in_memory_storage):


### PR DESCRIPTION
## Summary
- log report output through the logger instead of printing
- update tests to capture logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855503549588333a35b01530fec29b0