### PR TITLE
Remove unused io import

### DIFF
--- a/tests/test_theme_manager_cache.py
+++ b/tests/test_theme_manager_cache.py
@@ -1,4 +1,3 @@
-import io
 from pathlib import Path
 
 from src.services import ThemeManager


### PR DESCRIPTION
## Summary
- fix ruff unused import error in tests/test_theme_manager_cache.py

## Testing
- `ruff check tests/test_theme_manager_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_68555a26435083338ccc06d9f3ebe273