### PR TITLE
Add budget index

### DIFF
--- a/alembic/versions/0008_add_budget_index.py
+++ b/alembic/versions/0008_add_budget_index.py
@@ -1,0 +1,16 @@
+"""add index on budget.vehicle_id"""
+
+from alembic import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_budget_vehicle_id", "budget", ["vehicle_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_budget_vehicle_id", table_name="budget")

--- a/src/models/budget.py
+++ b/src/models/budget.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from sqlmodel import Field, SQLModel
+from sqlalchemy import Index
 
 
 class Budget(SQLModel, table=True):
@@ -11,3 +12,5 @@ class Budget(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     vehicle_id: int
     amount: float
+
+    __table_args__ = (Index("ix_budget_vehicle_id", "vehicle_id"),)

--- a/tests/test_inmemory_indexes.py
+++ b/tests/test_inmemory_indexes.py
@@ -7,8 +7,10 @@ def test_indexes_created_in_memory(in_memory_storage: StorageService) -> None:
     insp = sqlalchemy.inspect(engine)
     fuel_indexes = {idx["name"] for idx in insp.get_indexes("fuelentry")}
     maint_indexes = {idx["name"] for idx in insp.get_indexes("maintenance")}
+    budget_indexes = {idx["name"] for idx in insp.get_indexes("budget")}
     price_indexes = {idx["name"] for idx in insp.get_indexes("fuelprice")}
     assert "ix_fuelentry_vehicle_id" in fuel_indexes
     assert "ix_fuelentry_entry_date" in fuel_indexes
     assert "ix_maintenance_vehicle_id" in maint_indexes
+    assert "ix_budget_vehicle_id" in budget_indexes
     assert "ix_fuelprice_date_station_fuel_type" in price_indexes

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -25,8 +25,10 @@ def test_indexes_created(engine: Engine) -> None:
     insp = sqlalchemy.inspect(engine)
     fuel_indexes = {idx["name"] for idx in insp.get_indexes("fuelentry")}
     maint_indexes = {idx["name"] for idx in insp.get_indexes("maintenance")}
+    budget_indexes = {idx["name"] for idx in insp.get_indexes("budget")}
     price_indexes = {idx["name"] for idx in insp.get_indexes("fuelprice")}
     assert "ix_fuelentry_vehicle_id" in fuel_indexes
     assert "ix_fuelentry_entry_date" in fuel_indexes
     assert "ix_maintenance_vehicle_id" in maint_indexes
+    assert "ix_budget_vehicle_id" in budget_indexes
     assert "ix_fuelprice_date_station_fuel_type" in price_indexes


### PR DESCRIPTION
## Summary
- index `Budget.vehicle_id`
- test for the new index on in-memory and migrated DBs
- add Alembic migration for budget index

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68555ed700e88333a104350fe3de5496