### PR TITLE
Allow overriding API base in fetch_latest

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 `fetch_latest(session)` จะดาวน์โหลดราคาน้ำมันล่าสุดจาก Thai-Oil-API และบันทึกลงตาราง `FuelPrice` โดยจะข้ามวันที่มีข้อมูลอยู่แล้ว
 
+สามารถกำหนดฐาน URL ของ API ผ่านตัวแปรสภาพแวดล้อม `OIL_API_BASE` หรือตัวแปร `api_base` ในฟังก์ชัน `fetch_latest`
+
 ใช้ `get_price(session, fuel_type, station, date)` เพื่อดึงราคาน้ำมันในรูป `Decimal` หรือ `None` หากไม่มีข้อมูล
 
 หากเกิดข้อผิดพลาดด้านเครือข่าย ตรวจสอบว่าระบบอนุญาตให้เชื่อมต่อ HTTPS ไปยัง `api.chnwt.dev`

--- a/src/services/oil_service.py
+++ b/src/services/oil_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, Optional, cast
+import os
 
 import requests
 from sqlmodel import Session, select
@@ -65,10 +66,19 @@ def _parse_prices(data: Dict[str, Any], day: date, session: Session) -> None:
     session.commit()
 
 
-def fetch_latest(session: Session, station: str = "ptt") -> None:
-    """ดึงและบันทึกราคาน้ำมันล่าสุดจาก Thai Oil API"""
+def fetch_latest(
+    session: Session,
+    station: str = "ptt",
+    api_base: Optional[str] = None,
+) -> None:
+    """ดึงและบันทึกราคาน้ำมันล่าสุดจาก Thai Oil API
 
-    resp = _HTTP_SESSION.get(f"{API_BASE}/latest", timeout=5)
+    สามารถกำหนดฐาน URL ได้ผ่านพารามิเตอร์ ``api_base``
+    หรือผ่านตัวแปรสภาพแวดล้อม ``OIL_API_BASE``
+    """
+
+    base = api_base or os.getenv("OIL_API_BASE", API_BASE)
+    resp = _HTTP_SESSION.get(f"{base}/latest", timeout=5)
     resp.raise_for_status()
     data = resp.json()
     thai_date = data["response"]["date"]

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -25,7 +25,7 @@ def test_controller_reads_preferences(qapp, tmp_path, monkeypatch):
     monkeypatch.setattr(ctrl.thread_pool, "start", lambda job: job.run())
     monkeypatch.setattr(
         "src.controllers.main_controller.fetch_latest",
-        lambda s, station: calls.setdefault("station", station),
+        lambda s, station, api_base=None: calls.setdefault("station", station),
     )
     ctrl._schedule_price_update()
 


### PR DESCRIPTION
## Summary
- make API base configurable via env var or parameter
- document new option in API docs
- update oil service tests
- fix preferences test for new signature

## Testing
- `pytest tests/test_oil_service.py::test_fetch_latest -q`
- `pytest tests/test_oil_service.py::test_fetch_latest_env -q`
- `pytest tests/test_preferences.py::test_controller_reads_preferences -q`
- `pytest -q` *(fails: export/report page tests)*

------
https://chatgpt.com/codex/tasks/task_e_685560a9d8308333b665171f4d2afac7