### PR TITLE
Add PySide6-stubs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "types-keyboard",
     "types-reportlab",
     "matplotlib-stubs",
+    "PySide6-stubs",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add `PySide6-stubs` to the optional `dev` dependency group

## Testing
- `mypy src --strict`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685568088c8483338d28d5485e107907