### PR TITLE
Handle export errors in background job

### DIFF
--- a/tests/test_export_report_async.py
+++ b/tests/test_export_report_async.py
@@ -47,3 +47,37 @@ def test_export_report_runs_async(qtbot, main_controller, tmp_path, monkeypatch)
 
     with qtbot.waitSignal(ctrl.export_finished, timeout=2000):
         pass
+
+
+def test_export_report_failure_shows_error(qtbot, main_controller, tmp_path, monkeypatch):
+    ctrl = main_controller
+    qtbot.addWidget(ctrl.window)
+
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+    error_called = {}
+    monkeypatch.setattr(
+        QMessageBox, "critical", lambda *a, **k: error_called.setdefault("c", True)
+    )
+
+    def fail_csv(self, *_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ctrl.exporter, "monthly_csv", MethodType(fail_csv, ctrl.exporter))
+    monkeypatch.setattr(ctrl.exporter, "monthly_pdf", MethodType(lambda *a, **k: None, ctrl.exporter))
+
+    csv_path = tmp_path / "out.csv"
+    pdf_path = tmp_path / "out.pdf"
+    calls = []
+
+    def fake_get_save_file_name(*_a, **_k):
+        if not calls:
+            calls.append("csv")
+            return str(csv_path), ""
+        calls.append("pdf")
+        return str(pdf_path), ""
+
+    monkeypatch.setattr(QFileDialog, "getSaveFileName", fake_get_save_file_name)
+
+    with qtbot.waitSignal(ctrl.export_failed, timeout=2000):
+        ctrl.export_report()
+    assert error_called.get("c")


### PR DESCRIPTION
## Summary
- handle `export_report` exceptions with a new signal and error dialog
- verify user sees an error when export fails

## Testing
- `pytest -q tests/test_export_report_async.py -s`
- `pytest -q` *(fails: test_auto_migration, test_entrypoints_launch, test_ui_smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68556eb7902c8333a2bd94965d8cb945