### PR TITLE
Add Dependabot config and badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # FuelTracker
+[![Dependabot alerts](https://img.shields.io/badge/dependabot-enabled-brightgreen?logo=dependabot)](../../security/dependabot)
 
 โปรแกรมตัวอย่างแสดงโครงสร้าง MVC สำหรับบันทึกการใช้น้ำมัน
 


### PR DESCRIPTION
## Summary
- enable Dependabot for Python and GitHub Actions
- show Dependabot badge in the README

## Testing
- `pre-commit run --files .github/dependabot.yml README.md`
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68557e50cf5083338f4512d1bbc1878d