### PR TITLE
Enable auto-fill of liters

### DIFF
--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -4,6 +4,7 @@ import requests
 
 from PySide6.QtWidgets import QDialog
 from PySide6.QtCore import QTimer
+import pytest
 from sqlmodel import Session, select
 
 from src.services import oil_service
@@ -99,6 +100,36 @@ def test_autofill_liters(main_controller, monkeypatch):
     ctrl.open_add_entry_dialog()
     assert not dialog.litersEdit.isEnabled()
     assert not dialog.odoAfterEdit.isEnabled()
+
+
+def test_amount_edit_triggers_autofill(main_controller, monkeypatch):
+    ctrl = main_controller
+    ctrl.storage.add_vehicle(
+        Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
+    )
+
+    dialog = load_add_entry_dialog()
+
+    def fake_load():
+        return dialog
+
+    monkeypatch.setattr(
+        "src.controllers.main_controller.load_add_entry_dialog", fake_load
+    )
+    monkeypatch.setattr(
+        "src.controllers.main_controller.get_price", lambda *a, **k: Decimal("50")
+    )
+
+    def fake_exec():
+        dialog.amountEdit.setText("100")
+        dialog.amountEdit.editingFinished.emit()
+        return QDialog.Rejected
+
+    monkeypatch.setattr(dialog, "exec", fake_exec)
+
+    ctrl.open_add_entry_dialog()
+    assert float(dialog.litersEdit.text()) == pytest.approx(2.0)
+    assert not dialog.litersEdit.isEnabled()
 
 
 def test_price_update_handles_error(main_controller, monkeypatch):


### PR DESCRIPTION
## Summary
- connect Add Entry amount field to auto-fill logic
- calculate liters from amount and price when editing finishes
- add test for auto-fill computation

## Testing
- `export OIL_PRICE_RETENTION_DAYS=400 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685585755c588333bafce5162bb94971