### PR TITLE
Add liters update after price fetch

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -4,7 +4,12 @@ from .report_service import ReportService
 from .storage_service import StorageService
 from .exporter import Exporter
 from .importer import Importer
-from .oil_service import fetch_latest, get_price, purge_old_prices
+from .oil_service import (
+    fetch_latest,
+    get_price,
+    purge_old_prices,
+    update_missing_liters,
+)
 from .theme_manager import ThemeManager
 from .tray_icon_manager import TrayIconManager
 
@@ -16,6 +21,7 @@ __all__ = [
     "fetch_latest",
     "get_price",
     "purge_old_prices",
+    "update_missing_liters",
     "ThemeManager",
     "TrayIconManager",
 ]


### PR DESCRIPTION
## Summary
- update oil service API exports
- add helper to backfill liters using price data
- run backfill after downloading prices
- test that fetch_latest populates missing liters

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68558999e7c08333bc8b4af12c0630bd