### PR TITLE
Handle autofill toggle correctly

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -749,6 +749,7 @@ class MainController(QObject):
             try:
                 amount = Decimal(text)
             except Exception:
+                dialog.litersEdit.setEnabled(True)
                 return
 
             with Session(self.storage.engine) as session:
@@ -759,12 +760,16 @@ class MainController(QObject):
                     dialog.dateEdit.date().toPython(),
                 )
 
-            if price is not None:
-                liters = amount / price
-                dialog.litersEdit.setText(str(liters))
-                dialog.litersEdit.setEnabled(False)
+            if price is None:
+                dialog.litersEdit.setEnabled(True)
+                return
+
+            liters = amount / price
+            dialog.litersEdit.setText(str(liters))
+            dialog.litersEdit.setEnabled(False)
 
         dialog.amountEdit.editingFinished.connect(_auto_fill_liters)
+        dialog.autoFillCheckBox.toggled.connect(lambda _c: _auto_fill_liters())
 
         def _prefill() -> None:
             vid = dialog.vehicleComboBox.currentData()

--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -132,6 +132,63 @@ def test_amount_edit_triggers_autofill(main_controller, monkeypatch):
     assert not dialog.litersEdit.isEnabled()
 
 
+def test_autofill_toggle_enables_edit(main_controller, monkeypatch):
+    ctrl = main_controller
+    ctrl.storage.add_vehicle(
+        Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
+    )
+
+    dialog = load_add_entry_dialog()
+
+    def fake_load():
+        return dialog
+
+    monkeypatch.setattr(
+        "src.controllers.main_controller.load_add_entry_dialog", fake_load
+    )
+    monkeypatch.setattr(
+        "src.controllers.main_controller.get_price", lambda *a, **k: Decimal("50")
+    )
+
+    def fake_exec():
+        dialog.autoFillCheckBox.setChecked(False)
+        return QDialog.Rejected
+
+    monkeypatch.setattr(dialog, "exec", fake_exec)
+
+    ctrl.open_add_entry_dialog()
+    assert dialog.litersEdit.isEnabled()
+
+
+def test_missing_price_enables_manual_liters(main_controller, monkeypatch):
+    ctrl = main_controller
+    ctrl.storage.add_vehicle(
+        Vehicle(name="v", vehicle_type="t", license_plate="x", tank_capacity_liters=1)
+    )
+
+    dialog = load_add_entry_dialog()
+
+    def fake_load():
+        return dialog
+
+    monkeypatch.setattr(
+        "src.controllers.main_controller.load_add_entry_dialog", fake_load
+    )
+    monkeypatch.setattr(
+        "src.controllers.main_controller.get_price", lambda *a, **k: None
+    )
+
+    def fake_exec():
+        dialog.amountEdit.setText("100")
+        dialog.amountEdit.editingFinished.emit()
+        return QDialog.Rejected
+
+    monkeypatch.setattr(dialog, "exec", fake_exec)
+
+    ctrl.open_add_entry_dialog()
+    assert dialog.litersEdit.isEnabled()
+
+
 def test_price_update_handles_error(main_controller, monkeypatch):
     ctrl = main_controller
 


### PR DESCRIPTION
## Summary
- enable manual liter entry when fuel price is missing
- update Add Entry dialog to react to auto-fill toggle
- test auto-fill toggle behaviour

## Testing
- `pytest tests/test_oil_service.py::test_autofill_toggle_enables_edit -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6855f62003008333877e4361c3a5eac0