### PR TITLE
Improve auto calculation

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -65,7 +65,6 @@ else:
 
 from pathlib import Path
 import logging
-logger = logging.getLogger(__name__)
 import os
 import sys
 from datetime import datetime
@@ -107,6 +106,7 @@ from ..views import (
 from ..views.reports_page import ReportsPage
 from ..hotkey import GlobalHotkey
 
+logger = logging.getLogger(__name__)
 DEFAULT_FUEL_TYPE = "e20"
 
 
@@ -764,12 +764,13 @@ class MainController(QObject):
                 dialog.litersEdit.setEnabled(True)
                 return
 
-            liters = amount / price
+            liters = (amount / price).quantize(Decimal("0.01"))
             dialog.litersEdit.setText(str(liters))
             dialog.litersEdit.setEnabled(False)
 
         dialog.amountEdit.editingFinished.connect(_auto_fill_liters)
         dialog.autoFillCheckBox.toggled.connect(lambda _c: _auto_fill_liters())
+        dialog.dateEdit.dateChanged.connect(lambda _d: _auto_fill_liters())
 
         def _prefill() -> None:
             vid = dialog.vehicleComboBox.currentData()

--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -172,7 +172,11 @@ class StorageService:
                         prev.entry_date,
                     )
                     if price is not None:
-                        prev.liters = Decimal(str(prev.amount_spent)) / price
+                        prev.liters = float(
+                            (Decimal(str(prev.amount_spent)) / price).quantize(
+                                Decimal("0.01")
+                            )
+                        )
                 session.add(prev)
 
             # Auto-calculate liters for the current entry if possible
@@ -184,7 +188,11 @@ class StorageService:
                     entry.entry_date,
                 )
                 if price is not None:
-                    entry.liters = Decimal(str(entry.amount_spent)) / price
+                    entry.liters = float(
+                        (Decimal(str(entry.amount_spent)) / price).quantize(
+                            Decimal("0.01")
+                        )
+                    )
 
             session.add(entry)
             session.commit()

--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -278,3 +278,23 @@ def test_fetch_latest_updates_missing_liters(monkeypatch, in_memory_storage):
         updated = s.get(FuelEntry, entry.id)
         assert updated is not None
         assert updated.liters == pytest.approx(2.0)
+
+
+def test_get_price_fallback(in_memory_storage):
+    day1 = date(2024, 6, 1)
+    day2 = date(2024, 6, 3)
+    with Session(in_memory_storage.engine) as s:
+        s.add(
+            FuelPrice(
+                date=day1,
+                station="ptt",
+                fuel_type="e20",
+                name_th="E20",
+                price=Decimal("40"),
+            )
+        )
+        s.commit()
+
+        price = oil_service.get_price(s, "e20", "ptt", day2)
+        assert price == Decimal("40")
+


### PR DESCRIPTION
## Summary
- tweak automatic liter calculations
- fallback to previous price when missing
- recompute liters when the date changes
- round liter values to 2 decimal places
- test price fallback

## Testing
- `ruff check .`
- `mypy src --strict` *(fails: Library stubs not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6855195db9688333a73d2e2357ba167b