### PR TITLE
Handle fuel type in CSV imports and exports

### DIFF
--- a/docs/EXPORTING.md
+++ b/docs/EXPORTING.md
@@ -10,3 +10,13 @@
 การส่งออกเป็น Excel ต้องติดตั้งไลบรารี `openpyxl`.
 
 ทั้งสองเมทอดรับค่าเดือน ปี และเส้นทางปลายทางแบบ `Path`
+
+ไฟล์ CSV และ Excel จะมีคอลัมน์ดังนี้
+
+- `date`
+- `fuel_type`
+- `odo_before`
+- `odo_after`
+- `distance`
+- `liters`
+- `amount_spent`

--- a/src/services/exporter.py
+++ b/src/services/exporter.py
@@ -24,6 +24,7 @@ class Exporter:
             writer.writerow(
                 [
                     "date",
+                    "fuel_type",
                     "odo_before",
                     "odo_after",
                     "distance",
@@ -36,6 +37,7 @@ class Exporter:
                 writer.writerow(
                     [
                         e.entry_date.isoformat(),
+                        e.fuel_type or "",
                         e.odo_before,
                         e.odo_after,
                         dist,
@@ -51,7 +53,10 @@ class Exporter:
         y = 780
         for e in entries:
             dist = e.odo_after - e.odo_before if e.odo_after is not None else 0
-            line = f"{e.entry_date} - {dist} km, {e.liters or 0} L, THB {e.amount_spent or 0}"
+            line = (
+                f"{e.entry_date} - {dist} km, {e.liters or 0} L, THB {e.amount_spent or 0},"
+                f" {e.fuel_type or ''}"
+            )
             c.drawString(50, y, line)
             y -= 20
         c.save()
@@ -64,6 +69,7 @@ class Exporter:
             data.append(
                 {
                     "date": e.entry_date,
+                    "fuel_type": e.fuel_type,
                     "odo_before": e.odo_before,
                     "odo_after": e.odo_after,
                     "distance": dist,

--- a/src/services/importer.py
+++ b/src/services/importer.py
@@ -43,9 +43,11 @@ class Importer:
                     amount_val = float(amount) if amount else None
                 except ValueError:
                     amount_val = None
+                fuel_type = row.get("fuel_type") or None
                 entry = FuelEntry(
                     entry_date=entry_date,
                     vehicle_id=0,  # updated by ``import_csv``
+                    fuel_type=fuel_type,
                     odo_before=odo_before,
                     odo_after=odo_after_val,
                     amount_spent=amount_val,

--- a/tests/test_exporter_service.py
+++ b/tests/test_exporter_service.py
@@ -34,3 +34,10 @@ def test_exporter_creates_files(
     assert pdf_path.exists()
     assert xls_path.exists()
     assert pdf_path.stat().st_size > 0
+
+    import pandas as pd
+
+    df_csv = pd.read_csv(csv_path)
+    assert "fuel_type" in df_csv.columns
+    df_xls = pd.read_excel(xls_path)
+    assert "fuel_type" in df_xls.columns

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -33,6 +33,7 @@ def test_importer_roundtrip(tmp_path: Path):
         FuelEntry(
             entry_date=date(2024, 6, 1),
             vehicle_id=1,
+            fuel_type="gasoline_95",
             odo_before=0,
             odo_after=100,
             liters=20,
@@ -56,6 +57,7 @@ def test_importer_roundtrip(tmp_path: Path):
     assert len(saved) == len(entries) == 1
     assert saved[0].odo_after == 100
     assert saved[0].liters == 20
+    assert saved[0].fuel_type == "gasoline_95"
 
 
 def test_import_many_single_transaction(tmp_path: Path):
@@ -72,14 +74,15 @@ def test_import_many_single_transaction(tmp_path: Path):
         writer.writerow(
             [
                 "date",
+                "fuel_type",
                 "odo_before",
                 "odo_after",
                 "liters",
                 "amount_spent",
             ]
         )
-        writer.writerow(["2024-06-01", "0", "100", "20", "50"])
-        writer.writerow(["2024-06-02", "100", "200", "20", "50"])
+        writer.writerow(["2024-06-01", "gasoline_95", "0", "100", "20", "50"])
+        writer.writerow(["2024-06-02", "gasoline_95", "100", "200", "20", "50"])
 
     importer = Importer(storage)
 
@@ -96,6 +99,7 @@ def test_import_many_single_transaction(tmp_path: Path):
 
     assert len(entries) == 2
     assert commit_count - start == 1
+    assert entries[0].fuel_type == "gasoline_95"
 
 
 def test_prefill_odometer(main_controller, monkeypatch):


### PR DESCRIPTION
## Summary
- include fuel_type column in Exporter outputs
- import fuel_type from CSV files
- test coverage for the new column
- document available columns

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68560973d01c8333a792b701a4b50bbe