### PR TITLE
Allow custom fuel price station

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -188,7 +188,10 @@ class MainController(QObject):
         self.env = Settings()
         self.config_path = Path(config_path) if config_path else None
         self.config = AppConfig.load(self.config_path)
-        self.storage = StorageService(db_path or self.env.db_path)
+        self.storage = StorageService(
+            db_path or self.env.db_path,
+            default_station=self.config.default_station,
+        )
         self._dark_mode = dark_mode
         self._theme_override = theme.lower() if theme else None
         self.report_service = ReportService(self.storage)

--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -91,6 +91,7 @@ class StorageService:
         engine: Engine | None = None,
         password: str | None = None,
         vacuum_threshold: int = 100,
+        default_station: str = "ptt",
     ) -> None:
         """เริ่มต้นบริการจัดเก็บข้อมูล
 
@@ -103,9 +104,12 @@ class StorageService:
         vacuum_threshold:
             เรียก :meth:`vacuum` หลังจากเพิ่มข้อมูลด้วย :meth:`add_entry`
             ครบจำนวนครั้งที่กำหนด ค่าเริ่มต้น ``100``
+        default_station:
+            สถานีบริการน้ำมันเริ่มต้นสำหรับคำสั่งคำนวณอัตโนมัติ
         """
 
         self._vacuum_threshold = vacuum_threshold
+        self.default_station = default_station
         self._entry_counter = 0
 
         if engine is not None:
@@ -168,7 +172,7 @@ class StorageService:
                     price = get_price(
                         session,
                         prev.fuel_type or "e20",
-                        "ptt",
+                        self.default_station,
                         prev.entry_date,
                     )
                     if price is not None:
@@ -184,7 +188,7 @@ class StorageService:
                 price = get_price(
                     session,
                     entry.fuel_type or "e20",
-                    "ptt",
+                    self.default_station,
                     entry.entry_date,
                 )
                 if price is not None:


### PR DESCRIPTION
## Summary
- support configuring default station in `StorageService`
- use configured station when auto-calculating liters
- pass station preference from `MainController`

## Testing
- `ruff check src tests`
- `mypy src/ --strict` *(fails: unexpected indent in PySide6 stubs)*
- `pytest -q` *(fails: ImportError: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560e60cb1883339d3fabf357b37540