### PR TITLE
Call update_missing_liters during CSV import

### DIFF
--- a/src/services/importer.py
+++ b/src/services/importer.py
@@ -8,6 +8,7 @@ import csv
 from ..models import FuelEntry
 from .storage_service import StorageService
 from .validators import validate_entry
+from .oil_service import update_missing_liters
 from sqlmodel import Session
 
 
@@ -71,5 +72,6 @@ class Importer:
             for e in entries:
                 if e.id is not None:
                     session.refresh(e)
+            update_missing_liters(session)
 
         return entries


### PR DESCRIPTION
## Summary
- ensure missing liter values are filled after importing CSV data
- update importer tests for new behaviour
- add test verifying liter autofill when prices exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561134afe08333867b8bf0c7411f0a