### PR TITLE
Fix premium diesel key

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,7 +9,6 @@ FUEL_TYPE_TH: dict[str, str] = {
     "diesel": "ดีเซล B7",
     "premium_diesel": "ดีเซลพรีเมียม",
     "diesel_b20": "ดีเซล B20",
-    "diesel_premium": "ดีเซลพรีเมียม",
     "ngv": "เอ็นจีวี",
 }
 

--- a/tests/test_fuel_map.py
+++ b/tests/test_fuel_map.py
@@ -3,4 +3,4 @@ from src.constants import FUEL_TYPE_TH
 
 def test_fuel_type_map():
     assert FUEL_TYPE_TH["gasoline_95"] == "เบนซิน 95"
-    assert "diesel_premium" in FUEL_TYPE_TH
+    assert "premium_diesel" in FUEL_TYPE_TH


### PR DESCRIPTION
## Summary
- choose `premium_diesel` as the canonical key for premium diesel
- update references and tests

## Testing
- `pytest -q tests/test_fuel_map.py` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6856177b494c83338a5177705a3c93b7