### PR TITLE
Update importer to use storage default station

### DIFF
--- a/src/services/importer.py
+++ b/src/services/importer.py
@@ -72,6 +72,6 @@ class Importer:
             for e in entries:
                 if e.id is not None:
                     session.refresh(e)
-            update_missing_liters(session)
+            update_missing_liters(session, self.storage.default_station)
 
         return entries


### PR DESCRIPTION
## Summary
- ensure CSV import calculates liters using the storage's default station
- expand importer tests to cover default station usage

## Testing
- `pytest -k importer -q`

------
https://chatgpt.com/codex/tasks/task_e_685619ef7cac833394312a830d3371ff