### PR TITLE
Fix ruff issue in tests

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -96,7 +96,7 @@ def test_import_many_single_transaction(tmp_path: Path):
 
     event.listen(Session, "after_commit", count_commit)
     start = commit_count
-    entries = importer.import_csv(csv_path, 1)
+    importer.import_csv(csv_path, 1)
     event.remove(Session, "after_commit", count_commit)
 
     saved = storage.list_entries()


### PR DESCRIPTION
## Summary
- resolve an unused variable warning in `tests/test_importer.py`

## Testing
- `ruff check`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68561d7caedc833396eebc339b347c12