### PR TITLE
Document libegl1 dependency for PySide6 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@
 
 ## ความต้องการ
 
- - Python 3.11 or later
+- Python 3.11 or later
 - ติดตั้งแพ็กเกจที่ระบุใน `requirements.txt`
+- ติดตั้งแพ็กเกจระบบ `libegl1` (หรือเทียบเท่า) เพื่อให้การทดสอบที่ใช้ PySide6 ทำงานได้
+
+```bash
+sudo apt-get install libegl1
+```
 
 ## การติดตั้ง
 


### PR DESCRIPTION
## Summary
- note system package `libegl1` for PySide6 tests

## Testing
- `pip install -r requirements.txt`
- `sudo apt-get install -y libegl1`
- `pytest -q` *(fails to finish within time)*

------
https://chatgpt.com/codex/tasks/task_e_68564e4424788333a88ef8bef9b4b979