### PR TITLE
Cast raw connection for mypy

### DIFF
--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -560,7 +560,7 @@ class StorageService:
 
         backup_path = backup_dir / now.strftime("%y-%m-%d_%H%M.db")
 
-        source_conn = self.engine.raw_connection()
+        source_conn = cast(sqlcipher.Connection, self.engine.raw_connection())
         try:
             with sqlcipher.connect(str(backup_path)) as dest_conn:
                 if encrypted and _SQLCIPHER_AVAILABLE and self._password:


### PR DESCRIPTION
## Summary
- cast engine raw connection to `sqlcipher.Connection` in `auto_backup`

## Testing
- `poetry run poe _mypy` *(fails: Tasks prefixed with `_` cannot be executed directly)*

------
https://chatgpt.com/codex/tasks/task_e_685657dd2bac8333b56666a04e2c8f3e