### PR TITLE
Fix get_price typing

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -46,7 +46,7 @@ from shiboken6 import isValid
 from concurrent.futures import ThreadPoolExecutor
 from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QSystemTrayIcon
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, Optional
 
 if TYPE_CHECKING:
     from win10toast import ToastNotifier
@@ -109,8 +109,8 @@ from ..hotkey import GlobalHotkey
 logger = logging.getLogger(__name__)
 
 
-def get_price(*args, **kwargs):
-    """Wrapper to access :func:`src.services.oil_service.get_price`."""
+def get_price(*args: Any, **kwargs: Any) -> Optional[Decimal]:
+    """Wrapper for src.services.oil_service.get_price."""
     return _get_price(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- add Optional import near other typing imports
- type the get_price wrapper in main_controller
- run mypy

## Testing
- `mypy src/controllers/main_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_68565a1eea208333a05bac1a983d491b