### PR TITLE
Fix ThemeManager initialization

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -42,7 +42,7 @@ from PySide6.QtCore import (
     QDate,
     Slot,
 )
-from shiboken6 import isValid
+from shiboken6 import isValid  # type: ignore[attr-defined]
 from concurrent.futures import ThreadPoolExecutor
 from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QSystemTrayIcon
 
@@ -256,9 +256,7 @@ class MainController(QObject):
         self.window.installEventFilter(self)
         app = QApplication.instance()
         self.theme_manager = (
-            ThemeManager(cast(QApplication, app))
-            if isinstance(app, QApplication)
-            else None
+            ThemeManager(app) if isinstance(app, QApplication) else None
         )
         if app:
             app.aboutToQuit.connect(self.cleanup)


### PR DESCRIPTION
## Summary
- pass raw QApplication instance to ThemeManager
- silence shiboken6 attr-defined warning

## Testing
- `poetry run poe _mypy` *(fails: Tasks prefixed with `_` cannot be executed directly)*
- `poetry run mypy src/ --strict`

------
https://chatgpt.com/codex/tasks/task_e_68566a480dfc833382124e4a9f6b523b