### PR TITLE
Remove unused last_entries method

### DIFF
--- a/src/repositories/fuel_entry_repo.py
+++ b/src/repositories/fuel_entry_repo.py
@@ -22,16 +22,6 @@ class FuelEntryRepository:
             )
             return sess.exec(stmt).first()
 
-    def last_entries(self, vehicle_id: int, limit: int = 3) -> list[FuelEntry]:
-        """Return up to ``limit`` most recent entries for a vehicle."""
-        with Session(self.engine) as sess:
-            stmt = (
-                select(FuelEntry)
-                .where(FuelEntry.vehicle_id == vehicle_id)
-                .order_by(cast(Any, FuelEntry.entry_date).desc(), cast(Any, FuelEntry.id).desc())
-                .limit(limit)
-            )
-            return list(sess.exec(stmt))
 
     def add(self, entry: FuelEntry) -> FuelEntry:
         with Session(self.engine) as sess:


### PR DESCRIPTION
## Summary
- delete `last_entries` method from fuel entry repository

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_685678aa8e70833391b82a4a1dce323f