### PR TITLE
Remove unused hide_action in tray manager

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -270,7 +270,6 @@ class MainController(QObject):
         self.tray_manager = TrayIconManager(
             self.window,
             self.window.show,
-            self.window.hide,
             self.open_add_entry_dialog,
             self._tray_quit,
         )

--- a/src/services/tray_icon_manager.py
+++ b/src/services/tray_icon_manager.py
@@ -16,13 +16,11 @@ class TrayIconManager(QObject):
         self,
         parent: QWidget | None,
         show_action: Callable[[], None],
-        hide_action: Callable[[], None],
         add_entry_action: Callable[[], None],
         quit_action: Callable[[], None],
     ) -> None:
         super().__init__(parent)
         self._show_action = show_action
-        self._hide_action = hide_action
         self._add_entry_action = add_entry_action
         self._quit_action = quit_action
 


### PR DESCRIPTION
## Summary
- clean up TrayIconManager by removing unused `_hide_action`
- drop `hide_action` argument from constructor and calling code

## Testing
- `ruff check src/services/tray_icon_manager.py src/controllers/main_controller.py`
- `pytest -q` *(fails: fixture `qtbot` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567f5c9c688333b1e70d73d79a61b3