### PR TITLE
Fix variable names in tests

### DIFF
--- a/tests/test_oil_service.py
+++ b/tests/test_oil_service.py
@@ -43,7 +43,7 @@ SAMPLE = {
 called: dict[str, str] = {}
 
 
-def fake_get(url: str, timeout: int | None = None):
+def fake_get(url: str, _timeout: int | None = None, **_kwargs):
     called["url"] = url
 
     class R:

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -12,7 +12,7 @@ def test_mainwindow_launch(monkeypatch):
 
     # prevent blocking by skipping the event loop
     monkeypatch.setattr(QApplication, "exec", lambda self: 0)
-    monkeypatch.setattr(sys, "exit", lambda *a, **kw: None)
+    monkeypatch.setattr(sys, "exit", lambda *a, **_kw: None)
     shown = []
     monkeypatch.setattr(QMainWindow, "show", lambda self: shown.append(True))
 


### PR DESCRIPTION
## Summary
- rename `timeout` parameter in `fake_get` to `_timeout`
- rename `kw` capture in UI smoke test to `_kw`

## Testing
- `pytest -q tests/test_oil_service.py::test_fetch_latest tests/test_ui_smoke.py::test_mainwindow_launch` *(fails: ModuleNotFoundError / assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6856818f8d708333a07862cafdca5f45