### PR TITLE
Fix backup rotation lock issue

### DIFF
--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -561,12 +561,13 @@ class StorageService:
         backup_path = backup_dir / now.strftime("%y-%m-%d_%H%M.db")
 
         source_conn = cast(sqlcipher.Connection, self.engine.raw_connection())
+        dest_conn = sqlcipher.connect(str(backup_path))
         try:
-            with sqlcipher.connect(str(backup_path)) as dest_conn:
-                if encrypted and _SQLCIPHER_AVAILABLE and self._password:
-                    dest_conn.execute(f"PRAGMA key='{self._password}';")
-                source_conn.backup(dest_conn)
+            if encrypted and _SQLCIPHER_AVAILABLE and self._password:
+                dest_conn.execute(f"PRAGMA key='{self._password}';")
+            source_conn.backup(dest_conn)
         finally:
+            dest_conn.close()
             source_conn.close()
 
         if compress:


### PR DESCRIPTION
## Summary
- ensure backup file connection closes fully to avoid Windows locking

## Testing
- `pytest tests/test_backup.py::test_backup_rotation -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6856a9bd14548333b7ef3d2c2ff5a063