### PR TITLE
Fix unused ignore in hotkey

### DIFF
--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -17,7 +17,7 @@ def _ensure_keyboard() -> None:
     if keyboard is not _NOT_LOADED:
         return
     try:  # pragma: no cover - optional dependency
-        import keyboard as kb  # type: ignore
+        import keyboard as kb
         keyboard = kb
     except Exception:
         keyboard = None


### PR DESCRIPTION
## Summary
- remove unused mypy ignore

## Testing
- `poetry run mypy src/hotkey.py`
- `poetry run ruff check src/hotkey.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6856b0a1f71483338c64d540f1a421a0