### PR TITLE
Fix mypy method assignment

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -273,7 +273,7 @@ class MainController(QObject):
         )
         self.tray_manager.show()
         self._setup_hotkey()
-        self.window.closeEvent = self._close_event
+        self.window.closeEvent = self._close_event  # type: ignore[method-assign]
         if hasattr(self.window, "budgetEdit"):
             self.window.budgetEdit.setValidator(QDoubleValidator(0.0, 1e9, 2))
         self.refresh_vehicle_list()


### PR DESCRIPTION
## Summary
- ignore method assignment error for overriding `closeEvent`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6856c9ffba248333809f00e44d5c4dde