### PR TITLE
Remove obsolete type ignore

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -273,7 +273,7 @@ class MainController(QObject):
         )
         self.tray_manager.show()
         self._setup_hotkey()
-        self.window.closeEvent = self._close_event  # type: ignore[method-assign]
+        self.window.closeEvent = self._close_event
         if hasattr(self.window, "budgetEdit"):
             self.window.budgetEdit.setValidator(QDoubleValidator(0.0, 1e9, 2))
         self.refresh_vehicle_list()


### PR DESCRIPTION
## Summary
- drop `method-assign` ignore for closing the window

## Testing
- `mypy src/controllers/main_controller.py`
- `mypy src`

------
https://chatgpt.com/codex/tasks/task_e_6856d185f2688333a2017e026f9b98cd