### PR TITLE
Fix shadow effect on offscreen platforms

### DIFF
--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import sys
 from PySide6.QtCore import QDir
+from PySide6.QtWidgets import QApplication
 
 from .main_window import MainWindow
 from .dialogs import (
@@ -28,6 +29,11 @@ def asset_path(*parts: str) -> Path:
 
 # Allow Qt to resolve ``icons:`` paths inside .ui files.
 QDir.addSearchPath("icons", str(asset_path("icons")))
+
+
+def supports_shadow() -> bool:
+    """Return True if the current Qt platform supports drop shadows."""
+    return QApplication.platformName() not in {"offscreen", "minimal"}
 
 
 def load_add_entry_dialog() -> AddEntryDialog:
@@ -60,4 +66,5 @@ __all__ = [
     "load_add_entry_dialog",
     "load_add_vehicle_dialog",
     "load_about_dialog",
+    "supports_shadow",
 ]

--- a/src/views/reports_page.py
+++ b/src/views/reports_page.py
@@ -22,6 +22,7 @@ from matplotlib.figure import Figure
 import pandas as pd
 
 from ..services import ReportService
+from . import supports_shadow
 
 FigureCanvas = cast(Callable[[Figure], QWidget], FigureCanvasQTAgg)
 
@@ -38,9 +39,10 @@ class SummaryCard(QWidget):
         layout.addWidget(self.title_label)
         layout.addWidget(self.value_label)
         self.setStyleSheet("background:white;border-radius:12px;padding:8px;")
-        shadow = QGraphicsDropShadowEffect(self)
-        shadow.setBlurRadius(8)
-        self.setGraphicsEffect(shadow)
+        if supports_shadow():
+            shadow = QGraphicsDropShadowEffect(self)
+            shadow.setBlurRadius(8)
+            self.setGraphicsEffect(shadow)
 
     def set_value(self, text: str) -> None:
         self.value_label.setText(text)


### PR DESCRIPTION
## Summary
- guard creation of `QGraphicsDropShadowEffect` on unsupported platforms
- expose `supports_shadow()` helper

## Testing
- `ruff check .`
- `mypy src/ --strict`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856daec7cf4833388e0b1a247b8c6e8