### PR TITLE
Fix race condition in reports page test

### DIFF
--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -25,9 +25,12 @@ def test_refresh_clears_worker(qtbot, main_controller):
     ctrl = main_controller
     page = ctrl.reports_page
     qtbot.addWidget(page)
-    with qtbot.waitSignal(page.refresh_requested, timeout=2000):
-        page.refresh_button.click()
-    qtbot.waitUntil(lambda: page._worker is None, timeout=2000)
+    page.refresh_button.click()
+    worker = page._worker
+    assert worker is not None
+    with qtbot.waitSignal(worker.finished, timeout=2000):
+        pass
+    assert page._worker is None
 
 
 def test_vehicle_selection_updates_monthly(qtbot, main_controller, monkeypatch):


### PR DESCRIPTION
## Summary
- fix race condition in `test_refresh_clears_worker`

## Testing
- `pytest tests/test_reports_page.py::test_refresh_clears_worker -q`
- `pytest tests/test_reports_page.py::test_refresh_updates_summary -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ec7763908333b3c9889aded46cf8