### PR TITLE
Fix monthly tab population test

### DIFF
--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -18,7 +18,7 @@ def test_monthly_tab_populates(qtbot, main_controller):
     qtbot.addWidget(page)
     with qtbot.waitSignal(page.refresh_requested, timeout=2000):
         page.refresh_button.click()
-    assert page.monthly_layout.count() > 0
+    qtbot.waitUntil(lambda: page.monthly_layout.count() > 0)
 
 
 def test_refresh_clears_worker(qtbot, main_controller):


### PR DESCRIPTION
## Summary
- make the monthly tab test wait until layout has widgets

## Testing
- `pytest tests/test_reports_page.py::test_monthly_tab_populates -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685772acdea48333893bd9a85f7b3fe1