### PR TITLE
Fix monthly reports page test

### DIFF
--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -1,4 +1,5 @@
-from src.models import Vehicle
+from src.models import Vehicle, FuelEntry
+from datetime import date
 from src.services.report_service import ReportService
 import pandas as pd
 
@@ -14,6 +15,25 @@ def test_refresh_updates_summary(qtbot, main_controller):
 
 def test_monthly_tab_populates(qtbot, main_controller):
     ctrl = main_controller
+    storage = ctrl.storage
+    storage.add_vehicle(
+        Vehicle(
+            name="v1",
+            vehicle_type="t",
+            license_plate="x",
+            tank_capacity_liters=1,
+        )
+    )
+    storage.add_entry(
+        FuelEntry(
+            entry_date=date.today(),
+            vehicle_id=1,
+            odo_before=0.0,
+            odo_after=100.0,
+            amount_spent=50.0,
+            liters=5.0,
+        )
+    )
     page = ctrl.reports_page
     qtbot.addWidget(page)
     with qtbot.waitSignal(page.refresh_requested, timeout=2000):


### PR DESCRIPTION
## Summary
- add missing dependency to tests: set sample vehicle and fuel entry
- ensure monthly tab gets data before refresh

## Testing
- `pytest tests/test_reports_page.py::test_monthly_tab_populates -vv`

------
https://chatgpt.com/codex/tasks/task_e_68577875a28083339713be9c5040cfc3