### PR TITLE
Fix bare except in toast notifier

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -77,8 +77,10 @@ class ToastNotifier(object):
         self.wc.lpfnWndProc = message_map  # could also specify a wndproc.
         try:
             self.classAtom = RegisterClass(self.wc)
-        except:
-            pass #not sure of this
+        except Exception as exc:
+            # RegisterClass can fail if the class is already registered.
+            logging.debug("RegisterClass failed: %s", exc)
+            self.classAtom = self.wc.lpszClassName
         style = WS_OVERLAPPED | WS_SYSMENU
         self.hwnd = CreateWindow(self.classAtom, "Taskbar", style,
                                  0, 0, CW_USEDEFAULT,


### PR DESCRIPTION
## Summary
- handle potential RegisterClass errors in toast notification setup

## Testing
- `pytest win10toast_tests/test_win10toast_fix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68582bd945ac8333a63dfa4ec2666d62