### PR TITLE
Fix thread check in win10toast

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -138,7 +138,7 @@ class ToastNotifier(object):
 
     def notification_active(self):
         """See if we have an active notification showing"""
-        if self._thread != None and self._thread.is_alive():
+        if self._thread is not None and self._thread.is_alive():
             # We have an active notification, let is finish we don't spam them
             return True
         return False


### PR DESCRIPTION
## Summary
- avoid `!= None` in win10toast

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6858992e1d788333bcd32b339b4903d7