### PR TITLE
Add secure launcher and update build tasks

### DIFF
--- a/docs/UPDATER_SETUP.md
+++ b/docs/UPDATER_SETUP.md
@@ -1,0 +1,22 @@
+# TUF Update Repository Setup
+
+```bash
+# One-time setup for the FuelTracker update repository
+# Create repository structure
+mkdir fueltracker-updates && cd fueltracker-updates
+
+# Generate signing keys
+tufup repo keys create root.ed25519
+tufup repo keys create targets.ed25519
+
+# Initialize repository metadata
+tufup repo init FuelTracker
+
+# Register keys
+tufup repo keys add root root.ed25519.pub
+tufup repo keys add targets targets.ed25519.pub
+
+# Sign initial metadata
+tufup repo sign root
+tufup repo sign targets
+```

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,157 @@
+# FuelTracker launcher with secure updates
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Callable, Optional
+
+from packaging.version import Version
+from PyQt6.QtWidgets import QApplication, QProgressBar, QSplashScreen
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtCore import Qt
+from tufup.client import Client
+
+APP_NAME = "FuelTracker"
+PACKAGE = "fueltracker"
+CURRENT_VERSION = "0.1.0"
+UPDATE_URL = (
+    "https://raw.githubusercontent.com/org/fueltracker-updates/main/"
+)
+ROOT_KEY_HEX = "6ab4…c3"  # truncated example
+
+LOCALAPPDATA = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+APP_DIR = LOCALAPPDATA / APP_NAME
+LOG_FILE = APP_DIR / "launcher.log"
+MUTEX_NAME = "FuelTrackerLauncherMutex"
+
+
+@contextmanager
+def single_instance(name: str):
+    """Prevent concurrent launcher instances using a Windows mutex."""
+    handle = ctypes.windll.kernel32.CreateMutexW(None, False, name)
+    if ctypes.GetLastError() == 183:
+        sys.exit("Another instance is already running.")
+    try:
+        yield
+    finally:
+        ctypes.windll.kernel32.ReleaseMutex(handle)
+        ctypes.windll.kernel32.CloseHandle(handle)
+
+
+def setup_logging() -> None:
+    APP_DIR.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(
+        LOG_FILE, maxBytes=512 * 1024, backupCount=5, encoding="utf-8"
+    )
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+
+def read_current_version() -> str:
+    cur = APP_DIR / "current"
+    if cur.exists():
+        return cur.resolve().name
+    return CURRENT_VERSION
+
+
+class AppUpdater:
+    """Wrapper around ``tufup.Client``."""
+
+    def __init__(self) -> None:
+        self.metadata_dir = APP_DIR / "metadata"
+        self.target_dir = APP_DIR / "targets"
+        self.client = Client(
+            app_name=APP_NAME,
+            app_install_dir=APP_DIR,
+            current_version=read_current_version(),
+            metadata_dir=self.metadata_dir,
+            metadata_base_url=f"{UPDATE_URL}metadata/",
+            target_dir=self.target_dir,
+            target_base_url=f"{UPDATE_URL}targets/",
+        )
+
+    def check_for_update(self):
+        return self.client.check_for_updates()
+
+    def download_and_extract(self, progress: Callable[[int, int], None]):
+        self.client.download_and_apply_update(
+            skip_confirmation=True,
+            install=lambda *a, **k: None,
+            progress_hook=progress,
+        )
+        return Path(self.client.extract_dir), self.client.new_archive_meta.version
+
+
+def install_version(version: str, extracted: Path) -> Path:
+    dest = APP_DIR / version
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(extracted, dest)
+    current = APP_DIR / "current"
+    if current.exists():
+        if current.is_symlink() or current.is_file():
+            current.unlink()
+        else:
+            shutil.rmtree(current)
+    try:
+        current.symlink_to(dest, target_is_directory=True)
+    except OSError:
+        shutil.copytree(dest, current, dirs_exist_ok=True)
+    versions = sorted(
+        [p for p in APP_DIR.iterdir() if p.is_dir() and p.name[0].isdigit()],
+        key=lambda p: Version(p.name),
+        reverse=True,
+    )
+    for old in versions[2:]:
+        shutil.rmtree(old, ignore_errors=True)
+    return dest
+
+
+def run_app() -> None:
+    exe = APP_DIR / "current" / f"{APP_NAME}.exe"
+    if exe.exists():
+        subprocess.Popen([str(exe)])
+    else:
+        logging.error("Executable not found: %s", exe)
+
+
+def show_splash():
+    app = QApplication.instance() or QApplication(sys.argv[:1])
+    icon_path = Path(__file__).with_name("assets/icon.ico")
+    splash = QSplashScreen(QPixmap(str(icon_path)))
+    splash.show()
+    bar = QProgressBar(splash)
+    bar.setGeometry(0, splash.pixmap().height() - 25, splash.pixmap().width(), 20)
+    bar.setRange(0, 100)
+    bar.show()
+    return app, splash, bar
+
+
+def main() -> None:
+    setup_logging()
+    with single_instance(MUTEX_NAME):
+        app, splash, bar = show_splash()
+
+        def update_progress(bytes_downloaded: int, bytes_expected: int) -> None:
+            bar.setRange(0, bytes_expected)
+            bar.setValue(bytes_downloaded)
+            app.processEvents()
+
+        updater = AppUpdater()
+        meta = updater.check_for_update()
+        if meta and meta.version > Version(read_current_version()):
+            logging.info("Updating to %s", meta.version)
+            extracted, version = updater.download_and_extract(update_progress)
+            install_version(str(version), extracted)
+        splash.finish(None)
+    run_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/launcher.spec
+++ b/launcher.spec
@@ -1,0 +1,57 @@
+# -*- mode: python ; coding: utf-8 -*-
+import base64
+import os
+import certifi
+
+block_cipher = None
+
+ICON_B64 = (
+    "AAABAAMAEBAAAABoAwAAGgAAACAgAAAAPgAAACABAAIAAAAMAAABYwAAAAAEAAAAEAAAAAAAAAAAAAAA"  # small blank icon
+)
+ICON_PATH = os.path.join('assets', 'icon.ico')
+os.makedirs('assets', exist_ok=True)
+if not os.path.exists(ICON_PATH):
+    with open(ICON_PATH, 'wb') as f:
+        f.write(base64.b64decode(ICON_B64))
+
+a = Analysis(
+    ['launcher.py'],
+    pathex=[],
+    binaries=[],
+    datas=[(certifi.where(), 'cacert.pem')],
+    hiddenimports=['certifi'],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='FuelTrackerLauncher',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    icon=ICON_PATH,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='FuelTrackerLauncher',
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ migrate = { cmd = "python -m fueltracker migrate", env = { PYTHONPATH = "src" },
 test = { cmd = "python -m pytest -q", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite" }
 runtime-check = { cmd = "python -m fueltracker --check", env = { QT_QPA_PLATFORM = "offscreen", PYTHONPATH = "src" }, help = "Run app in headless mode" }
 build = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build standalone executable" }
+build-app = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build main FuelTracker.exe" }
+build-launcher = { cmd = "python -m PyInstaller --noconfirm --clean --onefile launcher.spec", help = "Build the launcher executable" }
+release = { shell = "poe build-app && poe build-launcher && zip -j dist/FuelTracker-${VERSION}-win64.zip dist/FuelTracker.exe && tufup repo targets add ${VERSION} dist/FuelTracker-${VERSION}-win64.zip && tufup repo sign timestamp && gh release create ${VERSION} dist/FuelTracker-${VERSION}-win64.zip --draft", help = "Create release" }
 validate = { sequence = ["lint", "test"], help = "Run linters then tests" }
 report = { sequence = ["lint", "test", "runtime-check"], help = "Run all checks" }
 

--- a/scripts/init_repo.sh
+++ b/scripts/init_repo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# One-time setup for tufup repository
+set -e
+
+# create update repository
+mkdir -p fueltracker-updates
+cd fueltracker-updates
+
+tufup repo init FuelTracker
+
+tufup repo keys create root.ed25519
+tufup repo keys create targets.ed25519
+
+tufup repo keys add root root.ed25519.pub
+tufup repo keys add targets targets.ed25519.pub
+
+tufup repo sign root
+tufup repo sign targets

--- a/tests/test_launcher_update.py
+++ b/tests/test_launcher_update.py
@@ -1,0 +1,35 @@
+import os
+import zipfile
+from pathlib import Path
+
+import launcher
+
+class DummyUpdater:
+    def __init__(self):
+        self.download_dir = Path(launcher.APP_DIR)
+        self.extract_dir = self.download_dir / "extract"
+        self.extract_dir.mkdir(parents=True, exist_ok=True)
+        self.new_archive_meta = type("Meta", (), {"version": "0.2.0"})()
+        self.archive = self.download_dir / "FuelTracker-0.2.0-win64.zip"
+        with zipfile.ZipFile(self.archive, "w") as zf:
+            zf.writestr("FuelTracker.exe", b"")
+
+    def check_for_update(self):
+        return self.new_archive_meta
+
+    def download_and_extract(self, progress):
+        with zipfile.ZipFile(self.archive) as zf:
+            zf.extractall(self.extract_dir)
+        return self.extract_dir, self.new_archive_meta.version
+
+
+def test_update_install(monkeypatch, tmp_path):
+    monkeypatch.setattr(launcher, "APP_DIR", tmp_path)
+    monkeypatch.setattr(launcher, "AppUpdater", DummyUpdater)
+    launcher.install_version("0.1.0", tmp_path)
+    assert (tmp_path / "current").exists()
+    result = launcher.main.__wrapped__ if hasattr(launcher.main, "__wrapped__") else launcher.main
+    result()  # run update flow
+    assert (tmp_path / "FuelTracker-0.2.0-win64.zip").exists()
+    assert (tmp_path / "0.2.0" / "FuelTracker.exe").exists()
+    assert (tmp_path / "current").resolve().name == "0.2.0"


### PR DESCRIPTION
## Summary
- create `launcher.py` that checks for updates with tufup and shows a PyQt6 splash
- provide PyInstaller `launcher.spec` bundling certifi certificates
- document repository setup for signed updates
- add tasks `build-app`, `build-launcher` and `release` to pyproject
- script for update repo initialisation
- test updater workflow

## Testing
- `pytest tests/test_launcher_update.py -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68582c16f1d48333abe500ece0f78dc8