### PR TITLE
Fix vulture false positives

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -8,6 +8,7 @@ from src.services import (
     storage_service,
 )
 from src import settings
+import tests.test_launcher_update
 
 _ = (
     # --- Attributes/Methods from main_controller.py that are used by Qt ---
@@ -35,6 +36,12 @@ _ = (
     storage_service.update_entry,
     # --- Variables used by Pydantic ---
     settings.model_config,
+    # --- Test helpers referenced dynamically ---
+    tests.test_launcher_update.DummyUpdater.check_for_update,
+    tests.test_launcher_update.DummyUpdater.download_and_extract,
+    tests.test_launcher_update.DummyApp.processEvents,
+    tests.test_launcher_update.DummySplash.finish,
+    tests.test_launcher_update.DummyBar.setRange,
 )
 
 __all__ = ["_"]

--- a/tests/test_launcher_update.py
+++ b/tests/test_launcher_update.py
@@ -19,7 +19,7 @@ class DummyUpdater:
     def check_for_update(self):
         return self.new_archive_meta
 
-    def download_and_extract(self, progress):
+    def download_and_extract(self, _progress):
         with zipfile.ZipFile(self.archive) as zf:
             zf.extractall(self.extract_dir)
         return self.extract_dir, self.new_archive_meta.version


### PR DESCRIPTION
## Summary
- add `tests.test_launcher_update` objects to the vulture whitelist
- mark the dummy updater's progress arg as unused

## Testing
- `pytest -q tests/test_launcher_update.py`

------
https://chatgpt.com/codex/tasks/task_e_6858c840afd88333aa0d7761c2c22b3a