### PR TITLE
Fix font and win10toast errors

### DIFF
--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -11,11 +11,16 @@ from pandas import DataFrame, Series
 import pandas as pd
 from fpdf import FPDF
 import matplotlib
+from matplotlib import font_manager
 from io import BytesIO
 import logging
 
 # Use a non-interactive backend for headless environments
 matplotlib.use("Agg")
+if any(f.name == "Noto Sans Thai" for f in font_manager.fontManager.ttflist):
+    matplotlib.rcParams["font.family"] = "Noto Sans Thai"
+else:
+    matplotlib.rcParams["font.family"] = "Tahoma"
 import matplotlib.pyplot as plt
 from matplotlib import dates as mdates
 from typing import Callable, cast

--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -13,8 +13,7 @@ import threading
 from typing import Optional
 from os import path
 from time import sleep
-from pkg_resources import Requirement
-from pkg_resources import resource_filename
+from pathlib import Path
 
 # 3rd party modules
 from win32api import GetModuleHandle
@@ -109,9 +108,7 @@ class ToastNotifier(object):
         if icon_path is not None:
             icon_path = path.realpath(icon_path)
         else:
-            icon_path = resource_filename(
-                Requirement.parse("win10toast"), "win10toast/data/python.ico"
-            )
+            icon_path = str(Path(__file__).resolve().parent / "data" / "python.ico")
         icon_flags = LR_LOADFROMFILE | LR_DEFAULTSIZE
         try:
             hicon = LoadImage(self.hinst, icon_path, IMAGE_ICON, 0, 0, icon_flags)


### PR DESCRIPTION
## Summary
- configure matplotlib to use a Thai-capable font
- avoid `pkg_resources` in `win10toast` when resolving the icon path

## Testing
- `ruff check src/services/report_service.py win10toast/__init__.py`
- `pytest win10toast_tests/test_win10toast_fix.py::test_no_wparam_crash -q` *(fails: PySide6 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858efbf9b6c8333a9ebfb1d6779e4fd