### PR TITLE
Replace pkg_resources usage

### DIFF
--- a/tests/test_entrypoints_launch.py
+++ b/tests/test_entrypoints_launch.py
@@ -1,11 +1,11 @@
 import subprocess
 import sys
-import pkg_resources
+from importlib.metadata import entry_points
 
 
 def test_entrypoints_launch():
     assert "fueltracker" in {
-        ep.name for ep in pkg_resources.iter_entry_points("console_scripts")
+        ep.name for ep in entry_points(group="console_scripts")
     }
     code = subprocess.check_output([sys.executable, "-m", "fueltracker", "--check"])
     assert b"MainWindow OK" in code


### PR DESCRIPTION
## Summary
- refactor test to use `importlib.metadata.entry_points`

## Testing
- `pytest tests/test_entrypoints_launch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858fd722b048333852b9eb0af64e79c