### PR TITLE
Switch to ExportService for PDF/XLSX reports

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -69,6 +69,7 @@ import os
 import sys
 from datetime import datetime
 import requests
+import shutil
 
 from ..settings import Settings
 
@@ -82,6 +83,7 @@ from ..services import (
     ReportService,
     StorageService,
     Exporter,
+    ExportService,
     Importer,
     ThemeManager,
     TrayIconManager,
@@ -196,6 +198,7 @@ class MainController(QObject):
         self._theme_override = theme.lower() if theme else None
         self.report_service = ReportService(self.storage)
         self.exporter = Exporter(self.storage)
+        self.export_service = ExportService(self.storage)
         self.importer = Importer(self.storage)
         self.window: MainWindow = MainWindow()
         self.global_hotkey: GlobalHotkey | None = None
@@ -1003,7 +1006,10 @@ class MainController(QObject):
         def job() -> None:
             try:
                 self.exporter.monthly_csv(today.month, today.year, out_csv)
-                self.exporter.monthly_pdf(today.month, today.year, out_pdf)
+                tmp = self.export_service.export_monthly_pdf(
+                    today.strftime("%Y-%m"), None
+                )
+                shutil.copy(tmp, out_pdf)
             except Exception as exc:  # pragma: no cover - handled in tests
                 self.export_failed.emit(str(exc))
             else:

--- a/src/services/exporter.py
+++ b/src/services/exporter.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 import csv
-import pandas as pd
-from reportlab.pdfgen import canvas
+import shutil
 
 from ..models import FuelEntry
 from .storage_service import StorageService
+from .export_service import ExportService
 
 
 class Exporter:
     def __init__(self, storage: StorageService) -> None:
         self.storage = storage
+        self.export_service = ExportService(storage)
 
     def _entries(self, month: int, year: int) -> List[FuelEntry]:
         return self.storage.list_entries_for_month(year, month)
@@ -47,36 +48,11 @@ class Exporter:
                 )
 
     def monthly_pdf(self, month: int, year: int, path: Path) -> None:
-        entries = self._entries(month, year)
-        c = canvas.Canvas(str(path))
-        c.drawString(50, 800, f"Fuel report {year}-{month:02d}")
-        y = 780
-        for e in entries:
-            dist = e.odo_after - e.odo_before if e.odo_after is not None else 0
-            line = (
-                f"{e.entry_date} - {dist} km, {e.liters or 0} L, THB {e.amount_spent or 0},"
-                f" {e.fuel_type or ''}"
-            )
-            c.drawString(50, y, line)
-            y -= 20
-        c.save()
+        """Create a monthly PDF report via :class:`ExportService`."""
+        tmp = self.export_service.export_monthly_pdf(f"{year}-{month:02d}", None)
+        shutil.copy(tmp, path)
 
     def monthly_excel(self, month: int, year: int, path: Path) -> None:
-        entries = self._entries(month, year)
-        data = []
-        for e in entries:
-            dist = e.odo_after - e.odo_before if e.odo_after is not None else None
-            data.append(
-                {
-                    "date": e.entry_date,
-                    "fuel_type": e.fuel_type,
-                    "odo_before": e.odo_before,
-                    "odo_after": e.odo_after,
-                    "distance": dist,
-                    "liters": e.liters,
-                    "amount_spent": e.amount_spent,
-                }
-            )
-        df = pd.DataFrame(data)
-        with pd.ExcelWriter(path) as writer:
-            df.to_excel(writer, index=False)
+        """Create a monthly Excel report via :class:`ExportService`."""
+        tmp = self.export_service.export_monthly_xlsx(f"{year}-{month:02d}")
+        shutil.copy(tmp, path)

--- a/tests/test_export_report_async.py
+++ b/tests/test_export_report_async.py
@@ -18,15 +18,19 @@ def test_export_report_runs_async(qtbot, main_controller, tmp_path, monkeypatch)
         assert Path(path) == csv_path
         time.sleep(0.2)
 
-    def slow_pdf(self, month, year, path):
-        assert Path(path) == pdf_path
+    def slow_pdf(self, month, vehicle_id):
+        assert vehicle_id is None
+        pdf_path.write_text("dummy")
         time.sleep(0.2)
+        return pdf_path
 
     monkeypatch.setattr(
         ctrl.exporter, "monthly_csv", MethodType(slow_csv, ctrl.exporter)
     )
     monkeypatch.setattr(
-        ctrl.exporter, "monthly_pdf", MethodType(slow_pdf, ctrl.exporter)
+        ctrl.export_service,
+        "export_monthly_pdf",
+        MethodType(slow_pdf, ctrl.export_service),
     )
 
     calls = []
@@ -68,7 +72,9 @@ def test_export_report_failure_shows_error(
         ctrl.exporter, "monthly_csv", MethodType(fail_csv, ctrl.exporter)
     )
     monkeypatch.setattr(
-        ctrl.exporter, "monthly_pdf", MethodType(lambda *a, **k: None, ctrl.exporter)
+        ctrl.export_service,
+        "export_monthly_pdf",
+        MethodType(lambda *a, **k: pdf_path, ctrl.export_service),
     )
 
     csv_path = tmp_path / "out.csv"


### PR DESCRIPTION
## Summary
- delegate Exporter PDF/XLSX exports to `ExportService`
- integrate `ExportService` in `MainController`
- adjust async export tests for new service

## Testing
- `ruff check .`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68594773510483338643a0411267fd06