### PR TITLE
Use appdirs for default config path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "openpyxl",
     "pydantic-settings",
     "rich",
+    "appdirs",
 ]
 
 [project.optional-dependencies]

--- a/src/config.py
+++ b/src/config.py
@@ -2,10 +2,11 @@ import json
 import os
 from dataclasses import dataclass, asdict
 from pathlib import Path
+from appdirs import user_config_dir
 
 from .settings import Settings
 
-CONFIG_PATH = Path.home() / ".fueltracker" / "config.json"
+CONFIG_PATH = Path(user_config_dir("FuelTracker")) / "config.json"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- depend on appdirs
- compute CONFIG_PATH with appdirs.user_config_dir

## Testing
- `ruff check src tests`
- `black src/config.py --check`
- `pytest -q` *(fails: ImportError cannot import name 'QStandardItemModel' from PySide6.QtWidgets)*

------
https://chatgpt.com/codex/tasks/task_e_68595ce98bd883338cccb64674f4b0b4