### PR TITLE
Store DB in user data dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example configuration for FuelTracker
 # Path to the SQLite database used by the application
+# Defaults to appdirs.user_data_dir("FuelTracker")/fuel.db
 DB_PATH=fuel.db
 # Theme selection: light, dark, or modern
 FT_THEME=light

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ pre-commit run --all-files
 คัดลอก `.env.example` ไปเป็น `.env` แล้วปรับค่าตามต้องการ
 เมื่อรันโปรแกรม [`python-dotenv`](https://pypi.org/project/python-dotenv/) จะโหลดตัวแปรจากไฟล์นี้ให้โดยอัตโนมัติ
 
-- `DB_PATH` กำหนดตำแหน่งฐานข้อมูล SQLite
+- `DB_PATH` กำหนดตำแหน่งฐานข้อมูล SQLite (ค่าเริ่มต้นคือ
+  `appdirs.user_data_dir("FuelTracker")/fuel.db`)
 - `FT_THEME` เลือกธีม `light`, `dark` หรือ `modern`
 - `FT_DB_PASSWORD` ตั้งรหัสผ่านเพื่อเปิดใช้ SQLCipher (ปล่อยว่างได้ถ้าไม่ต้องการ)
 - `OIL_API_BASE` กำหนด URL พื้นฐานสำหรับ API ราคาน้ำมัน (เขียนทับค่าที่ตั้งไว้)

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from appdirs import user_data_dir
+
+
+def data_dir() -> Path:
+    """Return the per-user data directory for FuelTracker."""
+    return Path(user_data_dir("FuelTracker"))
 
 
 class Settings(BaseSettings):
     """Application environment settings."""
 
-    db_path: Path = Field(default_factory=lambda: Path("fuel.db"))
+    db_path: Path = Field(default_factory=lambda: data_dir() / "fuel.db")
     ft_theme: str = Field(default="system")
     ft_db_password: str | None = None
     ft_cloud_dir: Path | None = None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,3 +9,13 @@ def test_env_loading(monkeypatch, tmp_path):
     assert settings.db_path == tmp_path / "my.db"
     assert settings.ft_theme == "modern"
     assert settings.appdata == tmp_path / "appdata"
+
+
+def test_default_db_location(monkeypatch, tmp_path):
+    monkeypatch.delenv("DB_PATH", raising=False)
+    monkeypatch.setattr(
+        "src.settings.user_data_dir",
+        lambda *_args, **_kwargs: str(tmp_path / "data"),
+    )
+    settings = Settings()
+    assert settings.db_path == tmp_path / "data" / "fuel.db"


### PR DESCRIPTION
## Summary
- add data_dir helper using `appdirs.user_data_dir`
- use this directory for the default database path
- document new default in README and `.env.example`
- test the computed default db location

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QStandardItemModel' from 'PySide6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_68595e504ef08333af6db559770f0840