### PR TITLE
Update default DB location

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Example configuration for FuelTracker
 # Path to the SQLite database used by the application
-# Defaults to appdirs.user_data_dir("FuelTracker")/fuel.db
+# Defaults to appdirs.user_data_dir("FuelTracker", "YourOrg")/fuel.db
 DB_PATH=fuel.db
 # Theme selection: light, dark, or modern
 FT_THEME=light

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pre-commit run --all-files
 เมื่อรันโปรแกรม [`python-dotenv`](https://pypi.org/project/python-dotenv/) จะโหลดตัวแปรจากไฟล์นี้ให้โดยอัตโนมัติ
 
 - `DB_PATH` กำหนดตำแหน่งฐานข้อมูล SQLite (ค่าเริ่มต้นคือ
-  `appdirs.user_data_dir("FuelTracker")/fuel.db`)
+  `appdirs.user_data_dir("FuelTracker", "YourOrg")/fuel.db`)
 - `FT_THEME` เลือกธีม `light`, `dark` หรือ `modern`
 - `FT_DB_PASSWORD` ตั้งรหัสผ่านเพื่อเปิดใช้ SQLCipher (ปล่อยว่างได้ถ้าไม่ต้องการ)
 - `OIL_API_BASE` กำหนด URL พื้นฐานสำหรับ API ราคาน้ำมัน (เขียนทับค่าที่ตั้งไว้)

--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from contextlib import closing
 
 from ..settings import Settings
+from appdirs import user_data_dir
 
 try:
     from pysqlcipher3 import dbapi2 as sqlcipher
@@ -88,7 +89,7 @@ class _ConnProxy:
 class StorageService:
     def __init__(
         self,
-        db_path: str | Path = "fuel.db",
+        db_path: str | Path = Path(user_data_dir("FuelTracker", "YourOrg")) / "fuel.db",
         engine: Engine | None = None,
         password: str | None = None,
         vacuum_threshold: int = 100,

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,7 +8,7 @@ from appdirs import user_data_dir
 
 def data_dir() -> Path:
     """Return the per-user data directory for FuelTracker."""
-    return Path(user_data_dir("FuelTracker"))
+    return Path(user_data_dir("FuelTracker", "YourOrg"))
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- default data directory uses app author
- update example environment variable and docs
- use user_data_dir default path for StorageService

## Testing
- `pip install -r requirements.lock`
- `pytest tests/test_settings.py::test_default_db_location -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68596687a4208333ba1169d640cc2da7