### PR TITLE
Add Windows build script without binary assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ ENV/
 
 # PyInstaller build artifacts
 build/
+!build/
+!build/*.bat
 dist/
 *.spec
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.txt

--- a/build/build_win.bat
+++ b/build/build_win.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal
+
+rem Change to repository root
+cd /d "%~dp0.."
+
+if not exist .venv (
+    python -m venv .venv
+)
+call .venv\Scripts\activate
+
+python -m pip install --upgrade pip >nul
+python -m pip install -r requirements.lock pyinstaller tufup >nul
+
+for /f "delims=" %%V in ('python -c "import sys;sys.path.insert(0,'src');import fueltracker;print(fueltracker.__version__)"') do set VERSION=%%V
+
+python -c "import os, pathlib, base64; ICON_B64='AAABAAMAEBAAAAAAIABLAAAANgAAABgYAAAAACAAUQAAAIEAAAAgIAAAAAAgAFMAAADSAAAAiVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAEklEQVR4nGNgGAWjYBSMAggAAAQQAAFVN1rQAAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAGElEQVR4nO3BAQEAAACAkP6v7ggKAICqAQkYAAHVDmlyAAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAACAAAAAgCAYAAABzenr0AAAAGklEQVR4nO3BAQEAAACCIP+vbkhAAQAAAO8GECAAARlDNO4AAAAASUVORK5CYII=';p=pathlib.Path('assets','fuel.ico');p.parent.mkdir(exist_ok=True);p.write_bytes(base64.b64decode(ICON_B64)); txt=pathlib.Path('version.txt').read_text(encoding='utf-8').replace('{__VERSION__}', os.environ['VERSION']); pathlib.Path('build','version_final.txt').write_text(txt, encoding='utf-8')"
+
+pyinstaller ^
+  --noconfirm --clean --windowed ^
+  --name FuelTracker ^
+  --icon assets\fuel.ico ^
+  --add-data "tuf_metadata\\root.json;tuf_metadata" ^
+  --version-file build\version_final.txt ^
+  src\fueltracker\__main__.py
+
+if exist dist\FuelTracker\FuelTracker.exe (
+    echo Build succeeded: dist\FuelTracker\FuelTracker.exe
+) else (
+    echo Build failed
+)
+
+endlocal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ dev = [
     "types-setuptools",
 ]
 
+
+win = [
+    "pyinstaller>=6.0",
+    "tufup>=0.9",
+]
+
 [project.scripts]
 fueltracker = "fueltracker.main:run"
 fueltracker-launcher = "launcher:main"

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,30 @@
+# UTF-8
+# Windows version information for FuelTracker
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(0, 0, 0, 0),
+    prodvers=(0, 0, 0, 0),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x4,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+    ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [
+        StringStruct('FileDescription', 'FuelTracker'),
+        StringStruct('FileVersion', '{__VERSION__}'),
+        StringStruct('ProductVersion', '{__VERSION__}'),
+        StringStruct('OriginalFilename', 'FuelTracker.exe'),
+        StringStruct('InternalName', 'FuelTracker'),
+        StringStruct('ProductName', 'FuelTracker')
+        ]
+      )
+      ]),
+    VarFileInfo([VarStruct('Translation', [1033, 1200])])
+  ]
+)


### PR DESCRIPTION
## Summary
- remove `assets/fuel.ico` binary and generate icon in build script
- decode icon and inject version info in `build_win.bat`
- package `version.txt` via `MANIFEST.in`
- list optional Windows dependencies in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QStandardItemModel' from 'PySide6.QtWidgets')*

------
https://chatgpt.com/codex/tasks/task_e_6859682ce6f08333a02eb385d82bc7c1