### PR TITLE
Add SQL monthly totals

### DIFF
--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -136,29 +136,18 @@ class ReportService:
 
     def get_monthly_stats(self, month: date, vehicle_id: int) -> Dict[str, float]:
         """คำนวณผลรวมและค่าเฉลี่ยของเดือนสำหรับยานพาหนะ"""
-        df = self._monthly_df(month, vehicle_id)
-        if df.empty:
-            return {
-                "total_distance": 0.0,
-                "total_liters": 0.0,
-                "total_price": 0.0,
-                "avg_consumption": 0.0,
-                "cost_per_km": 0.0,
-                "fills_count": 0,
-                "avg_price_per_liter": 0.0,
-            }
+        total_distance, total_liters, total_price = self.storage.vehicle_monthly_stats(
+            vehicle_id, month.year, month.month
+        )
+        fills_count = len(
+            self.storage.list_entries_for_month(month.year, month.month, vehicle_id)
+        )
 
-        total_distance = float(df["distance"].fillna(0).sum())
-        total_liters = float(df["liters"].fillna(0).sum())
-        total_price = float(df["amount_spent"].sum())
         avg_consumption = (
             (total_liters / total_distance * 100) if total_distance else 0.0
         )
         cost_per_km = (total_price / total_distance) if total_distance else 0.0
-        fills_count = len(df)
-        avg_price_per_liter = (
-            (total_price / total_liters) if total_liters else 0.0
-        )
+        avg_price_per_liter = (total_price / total_liters) if total_liters else 0.0
 
         return {
             "total_distance": total_distance,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -130,3 +130,43 @@ def test_get_vehicle_stats(in_memory_storage: StorageService) -> None:
     assert dist == manual_distance
     assert liters == manual_liters
     assert price == manual_price
+
+
+def test_vehicle_monthly_stats(in_memory_storage: StorageService) -> None:
+    storage = in_memory_storage
+    storage.add_entry(
+        FuelEntry(
+            entry_date=date(2024, 1, 1),
+            vehicle_id=1,
+            odo_before=0,
+            odo_after=100,
+            amount_spent=20,
+            liters=10,
+        )
+    )
+    storage.add_entry(
+        FuelEntry(
+            entry_date=date(2024, 1, 15),
+            vehicle_id=1,
+            odo_before=100,
+            odo_after=None,
+            amount_spent=10,
+            liters=5,
+        )
+    )
+    storage.add_entry(
+        FuelEntry(
+            entry_date=date(2024, 2, 1),
+            vehicle_id=1,
+            odo_before=100,
+            odo_after=200,
+            amount_spent=16,
+            liters=8,
+        )
+    )
+
+    dist, liters, price = storage.vehicle_monthly_stats(1, 2024, 1)
+
+    assert dist == 100.0
+    assert liters == 15.0
+    assert price == 30.0


### PR DESCRIPTION
## Summary
- add `vehicle_monthly_stats` in `StorageService`
- compute monthly stats directly from SQL in `ReportService`
- test the new statistics helper

## Testing
- `pytest tests/test_reports.py::test_get_monthly_stats tests/test_storage.py::test_vehicle_monthly_stats -q`
- `pytest tests/test_storage.py::test_get_vehicle_stats -q`

------
https://chatgpt.com/codex/tasks/task_e_6859fcb916708333b1c69e37123d6208