### PR TITLE
Enable test coverage reports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,6 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest -q
+        entry: pytest --cov=src --cov-report=term-missing -q
         language: system
         types: [python]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ pip install poethepoet
 
 - `poe lint` - รัน `ruff`, `mypy` และ `vulture` เพื่อตรวจสอบคุณภาพโค้ด
 - `poe test` - รันชุดทดสอบด้วย `pytest` หลังจากอัปเกรดฐานข้อมูล
+- `poe cover` - รันชุดทดสอบพร้อมรายงาน coverage
 - `poe migrate` - รันสคริปต์ `alembic` เพื่ออัปเกรดฐานข้อมูล
 - `poe runtime-check` - เปิดโปรแกรมแบบไม่สร้างหน้าต่างเพื่อตรวจสอบการทำงาน
 - `poe build` - สร้างไฟล์ปฏิบัติการแบบ standalone ด้วย `PyInstaller`
@@ -110,6 +111,12 @@ pytest
 ```bash
 ./scripts/dev_setup.sh
 pytest
+```
+
+หากต้องการดูรายงาน coverage ใช้คำสั่ง:
+
+```bash
+poe cover
 ```
 
 ## การแก้ปัญหา

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     # Testing
     "pytest",
     "pytest-qt",
+    "pytest-cov",
 
     # Type Stubs
     "types-requests",
@@ -74,6 +75,7 @@ _vulture = { cmd = "python -m vulture src tests .vulture-whitelist.py", help = "
 lint = { sequence = ["_ruff", "_mypy", "_vulture"], help = "Run all linters" }
 migrate = { cmd = "python -m fueltracker migrate", env = { PYTHONPATH = "src" }, help = "Run database migrations" }
 test = { cmd = "python -m pytest -q", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite" }
+cover = { cmd = "python -m pytest --cov=src --cov-report=term-missing", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite with coverage" }
 runtime-check = { cmd = "python -m fueltracker --check", env = { QT_QPA_PLATFORM = "offscreen", PYTHONPATH = "src" }, help = "Run app in headless mode" }
 build = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build standalone executable" }
 build-app = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build main FuelTracker.exe" }


### PR DESCRIPTION
## Summary
- include `pytest-cov` in development extras
- add `poe cover` task to run tests with coverage
- document running coverage in README
- run tests with coverage in pre-commit hook

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6859fdc6f7e08333992a6a0784d39532