### PR TITLE
Improve async export test speed

### DIFF
--- a/tests/test_export_report_async.py
+++ b/tests/test_export_report_async.py
@@ -16,13 +16,13 @@ def test_export_report_runs_async(qtbot, main_controller, tmp_path, monkeypatch)
 
     def slow_csv(self, month, year, path):
         assert Path(path) == csv_path
-        time.sleep(0.2)
+        csv_path.write_text("csv")
 
     def slow_pdf(self, month, vehicle_id):
         assert vehicle_id is None
-        pdf_path.write_text("dummy")
-        time.sleep(0.2)
-        return pdf_path
+        tmp_pdf = tmp_path / "temp.pdf"
+        tmp_pdf.write_text("dummy")
+        return tmp_pdf
 
     monkeypatch.setattr(
         ctrl.exporter, "monthly_csv", MethodType(slow_csv, ctrl.exporter)


### PR DESCRIPTION
## Summary
- speed up `test_export_report_runs_async`
- use temporary PDF path so the copy step doesn't fail

## Testing
- `pytest tests/test_export_report_async.py::test_export_report_runs_async -q`
- `pytest -q` *(fails: RuntimeError: Could not determine home directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a13569b188333bba0792104854581