### PR TITLE
Improve toast test synchronization

### DIFF
--- a/win10toast/__init__.py
+++ b/win10toast/__init__.py
@@ -147,7 +147,7 @@ class ToastNotifier(object):
         icon_path: str | None = None,
         duration: int = 5,
         threaded: bool = False,
-    ) -> bool:
+    ) -> bool | threading.Thread:
         """Notification settings.
 
         :title: notification title
@@ -157,18 +157,19 @@ class ToastNotifier(object):
         """
         if not threaded:
             self._show_toast(title, msg, icon_path, duration)
-        else:
-            if self.notification_active():
-                # We have an active notification, let is finish so we don't spam them
-                return False
+            return True
 
-            t = threading.Thread(
-                target=self._show_toast,
-                args=(title, msg, icon_path, duration),
-            )
-            self._thread = t
-            t.start()
-        return True
+        if self.notification_active():
+            # We have an active notification, let it finish so we don't spam them
+            return False
+
+        t = threading.Thread(
+            target=self._show_toast,
+            args=(title, msg, icon_path, duration),
+        )
+        self._thread = t
+        t.start()
+        return t
 
     def notification_active(self) -> bool:
         """See if we have an active notification showing"""

--- a/win10toast_tests/test_win10toast_fix.py
+++ b/win10toast_tests/test_win10toast_fix.py
@@ -1,6 +1,6 @@
 import sys
 import types
-import time
+import threading
 
 
 def test_no_wparam_crash(monkeypatch):
@@ -59,5 +59,6 @@ def test_no_wparam_crash(monkeypatch):
     from win10toast import ToastNotifier
 
     tn = ToastNotifier()
-    tn.show_toast("hi", "body", threaded=True)
-    time.sleep(0.2)
+    thread = tn.show_toast("hi", "body", duration=0, threaded=True)
+    assert isinstance(thread, threading.Thread)
+    thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- return the thread from `ToastNotifier.show_toast` when using `threaded=True`
- wait for the toast thread in the win10toast fix test instead of sleeping

## Testing
- `mypy win10toast/__init__.py win10toast_tests/test_win10toast_fix.py`
- `pytest win10toast_tests/test_win10toast_fix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1c97f9488333a101d16027885d07