### PR TITLE
Patch sleep in backup test

### DIFF
--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -17,7 +17,8 @@ from src.services.storage_service import _SQLCIPHER_AVAILABLE
 from src.models import Vehicle
 
 
-def test_backup_rotation(tmp_path):
+def test_backup_rotation(tmp_path, monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda *_args, **_kwargs: None)
     db = tmp_path / "fuel.db"
     storage = StorageService(db_path=db)
     storage.add_vehicle(


### PR DESCRIPTION
## Summary
- stop slow waits in `test_backup_rotation`

## Testing
- `pytest -k test_backup.py::test_backup_rotation -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685a1e87cf188333a9f07a810aefe79d