### PR TITLE
Enable parallel pytest runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,6 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest --cov=src --cov-report=term-missing -q
+        entry: pytest -n auto --cov=src --cov-report=term-missing -q
         language: system
         types: [python]

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ pip install poethepoet
 งานที่มีให้ใช้งานประกอบด้วย
 
 - `poe lint` - รัน `ruff`, `mypy` และ `vulture` เพื่อตรวจสอบคุณภาพโค้ด
-- `poe test` - รันชุดทดสอบด้วย `pytest` หลังจากอัปเกรดฐานข้อมูล
-- `poe cover` - รันชุดทดสอบพร้อมรายงาน coverage
+- `poe test` - รันชุดทดสอบด้วย `pytest -n auto` หลังจากอัปเกรดฐานข้อมูล
+- `poe cover` - รันชุดทดสอบพร้อมรายงาน coverage ด้วย `pytest -n auto`
 - `poe migrate` - รันสคริปต์ `alembic` เพื่ออัปเกรดฐานข้อมูล
 - `poe runtime-check` - เปิดโปรแกรมแบบไม่สร้างหน้าต่างเพื่อตรวจสอบการทำงาน
 - `poe build` - สร้างไฟล์ปฏิบัติการแบบ standalone ด้วย `PyInstaller`
@@ -88,7 +88,7 @@ pip install -e .[dev]
 คำสั่งนี้จะลงไทป์สตับ รวมถึง `types-requests` เพื่อให้ `mypy` ตรวจสอบ
 การนำเข้าไลบรารี `requests` ได้อย่างครบถ้วน
 
-ฮุคจะรัน `ruff`, `black`, `mypy` และ `pytest` ทุกครั้งที่คอมมิต
+ฮุคจะรัน `ruff`, `black`, `mypy` และ `pytest -n auto` ทุกครั้งที่คอมมิต
 หากต้องการรันทั้งหมดด้วยตนเองให้ใช้:
 
 ```bash
@@ -103,14 +103,14 @@ pre-commit run --all-files
 ```bash
 pip install -r requirements.lock
 pip install -e .[dev]
-pytest
+pytest -n auto
 ```
 
 สามารถเรียกสคริปต์ `scripts/dev_setup.sh` เพื่อทำขั้นตอนติดตั้งให้อัตโนมัติได้เช่นกัน:
 
 ```bash
 ./scripts/dev_setup.sh
-pytest
+pytest -n auto
 ```
 
 หากต้องการดูรายงาน coverage ใช้คำสั่ง:
@@ -195,7 +195,7 @@ poe build
 
 ## การทดสอบบน Windows
 
-หลังจากติดตั้งโปรเจ็กต์ตามขั้นตอนด้านบน สามารถรันทดสอบทั้งหมดได้ด้วย `pytest`
+หลังจากติดตั้งโปรเจ็กต์ตามขั้นตอนด้านบน สามารถรันทดสอบทั้งหมดได้ด้วย `pytest -n auto`
 โดยทำงานภายใน virtual environment:
 
 ```bat
@@ -204,11 +204,11 @@ python -m venv .venv
 pip install -r requirements.lock
 rem requirements.lock รวม `pytest-qt` ซึ่งให้ฟิกซ์เจอร์ `qtbot` สำหรับทดสอบ Qt
 pip install -e .
-pytest
+pytest -n auto
 ```
 
 ต้องการตรวจสอบแบบครบถ้วนยิ่งขึ้นสามารถใช้คำสั่ง `poe validate`
-ซึ่งจะติดตั้งแพ็กเกจแบบ editable รัน `pytest` และทดสอบการเปิดโปรแกรมแบบ
+ซึ่งจะติดตั้งแพ็กเกจแบบ editable รัน `pytest -n auto` และทดสอบการเปิดโปรแกรมแบบ
 offscreen ผลลัพธ์จะถูกบันทึกไว้ในโฟลเดอร์ `reports/` ทั้งหมด ก่อนใช้งานให้ติดตั้งเครื่องมือสำหรับนักพัฒนาดังนี้
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest",
     "pytest-qt",
     "pytest-cov",
+    "pytest-xdist",
 
     # Type Stubs
     "types-requests",
@@ -74,8 +75,8 @@ _vulture = { cmd = "python -m vulture src tests .vulture-whitelist.py", help = "
 
 lint = { sequence = ["_ruff", "_mypy", "_vulture"], help = "Run all linters" }
 migrate = { cmd = "python -m fueltracker migrate", env = { PYTHONPATH = "src" }, help = "Run database migrations" }
-test = { cmd = "python -m pytest -q", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite" }
-cover = { cmd = "python -m pytest --cov=src --cov-report=term-missing", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite with coverage" }
+test = { cmd = "python -m pytest -n auto -q", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite" }
+cover = { cmd = "python -m pytest -n auto --cov=src --cov-report=term-missing", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite with coverage" }
 runtime-check = { cmd = "python -m fueltracker --check", env = { QT_QPA_PLATFORM = "offscreen", PYTHONPATH = "src" }, help = "Run app in headless mode" }
 build = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build standalone executable" }
 build-app = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build main FuelTracker.exe" }


### PR DESCRIPTION
## Summary
- add `pytest-xdist` to dev dependencies
- run tests with `pytest -n auto` via Poe the Poet and pre-commit
- update README instructions for running tests in parallel

## Testing
- `poe test` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685a2455c598833393559106e84f7a42