### PR TITLE
Fix PyInstaller icon artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ dist/
 
 # Misc
 assets/ui.png
+assets/app.ico
 
 # Temporary databases created during testing
 fuel.db


### PR DESCRIPTION
## Summary
- ignore `assets/app.ico` generated by PyInstaller

## Testing
- `pip install -r requirements.lock`
- `pip install -e .[dev]`
- `pytest -n auto` *(fails: table alembic_version already exists)*

------
https://chatgpt.com/codex/tasks/task_e_685a32e283cc8333b2ce330c4183099b