### PR TITLE
Add Thai validation messages

### DIFF
--- a/src/services/validators.py
+++ b/src/services/validators.py
@@ -6,9 +6,9 @@ from ..models import FuelEntry
 def validate_entry(entry: FuelEntry) -> None:
     """ตรวจสอบ :class:`FuelEntry` ก่อนบันทึก"""
     if entry.odo_after is not None and entry.odo_after < entry.odo_before:
-        raise ValueError("odo_after must be >= odo_before")
+        raise ValueError("ค่าเลขไมล์หลังเติมต้องมากกว่าหรือเท่ากับก่อนเติม")
     # ``liters`` cannot be stored without a corresponding ``amount_spent`` value.
     # When adding a new refuel entry the liters are calculated later, so
     # ``amount_spent`` may be provided without ``liters``.
     if entry.liters is not None and entry.amount_spent is None:
-        raise ValueError("amount_spent must be given with liters")
+        raise ValueError("ต้องระบุจำนวนเงินเมื่อระบุจำนวนลิตร")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,7 +17,7 @@ def test_invalid_odometer(tmp_path):
         amount_spent=10.0,
         liters=1.0,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="ค่าเลขไมล์หลังเติมต้องมากกว่าหรือเท่ากับก่อนเติม"):
         storage.add_entry(entry)
 
 
@@ -34,5 +34,5 @@ def test_liters_requires_amount(tmp_path):
         amount_spent=None,
         liters=5.0,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="ต้องระบุจำนวนเงินเมื่อระบุจำนวนลิตร"):
         storage.add_entry(entry)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -15,7 +15,7 @@ def test_odo_after_less_than_before_raises():
         amount_spent=50.0,
         liters=5.0,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="ค่าเลขไมล์หลังเติมต้องมากกว่าหรือเท่ากับก่อนเติม"):
         validate_entry(entry)
 
 
@@ -28,7 +28,7 @@ def test_liters_without_amount_raises():
         amount_spent=None,
         liters=5.0,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="ต้องระบุจำนวนเงินเมื่อระบุจำนวนลิตร"):
         validate_entry(entry)
 
 


### PR DESCRIPTION
## Summary
- localize validation errors to Thai
- check Thai error messages in validators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a41c8e5dc83338719a5f54147c315