### PR TITLE
Update check message

### DIFF
--- a/reports/connectivity_report.md
+++ b/reports/connectivity_report.md
@@ -3,5 +3,5 @@ Ruff exit: 0
 Vulture exit: 3
 Mypy exit: 1
 Pytest exit: 0
-MainWindow OK
+หน้าต่างหลักทำงานได้
 Errors: vulture, mypy

--- a/src/fueltracker/main.py
+++ b/src/fueltracker/main.py
@@ -97,7 +97,7 @@ def run(argv: list[str] | None = None) -> None:
     if args.check:
         QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_Use96Dpi, True)
         window.show()
-        print("MainWindow OK")
+        print("หน้าต่างหลักทำงานได้")
         return
 
     window.show()

--- a/tests/test_entrypoints_launch.py
+++ b/tests/test_entrypoints_launch.py
@@ -4,8 +4,6 @@ from importlib.metadata import entry_points
 
 
 def test_entrypoints_launch():
-    assert "fueltracker" in {
-        ep.name for ep in entry_points(group="console_scripts")
-    }
+    assert "fueltracker" in {ep.name for ep in entry_points(group="console_scripts")}
     code = subprocess.check_output([sys.executable, "-m", "fueltracker", "--check"])
-    assert b"MainWindow OK" in code
+    assert "หน้าต่างหลักทำงานได้".encode() in code


### PR DESCRIPTION
## Summary
- update check-mode message to Thai text
- adjust test to expect new text
- update connectivity report reference

## Testing
- `ruff check src/fueltracker/main.py tests/test_entrypoints_launch.py`
- `black --check src/fueltracker/main.py tests/test_entrypoints_launch.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685a56f0d1e48333a1608f4159d73091