### PR TITLE
Fix date annotation in FuelPrice model

### DIFF
--- a/src/models/fuel_price.py
+++ b/src/models/fuel_price.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+import datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -12,7 +12,7 @@ class FuelPrice(SQLModel, table=True):
     """ราคาน้ำมันรายวันของสถานีและประเภทเชื้อเพลิง"""
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    date: date
+    date: datetime.date
     station: str
     fuel_type: str
     name_th: str


### PR DESCRIPTION
## Summary
- import `datetime` instead of `date`
- annotate `FuelPrice.date` with `datetime.date`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a62e1175c8333acc1d4db3dae62ad