### PR TITLE
Remove egg-info directory and update ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ ENV/
 
 # Package metadata
 *.egg-info/
+fueltracker.egg-info/
 
 # IDE settings
 .idea/

--- a/fueltracker.egg-info/PKG-INFO
+++ b/fueltracker.egg-info/PKG-INFO
@@ -1,4 +1,0 @@
-Metadata-Version: 2.1
-Name: fueltracker
-Version: 0.1.0
-Summary: Fuel tracker sample application

--- a/fueltracker.egg-info/entry_points.txt
+++ b/fueltracker.egg-info/entry_points.txt
@@ -1,2 +1,0 @@
-[console_scripts]
-fueltracker = fueltracker.main:run

--- a/fueltracker.egg-info/top_level.txt
+++ b/fueltracker.egg-info/top_level.txt
@@ -1,1 +1,0 @@
-fueltracker


### PR DESCRIPTION
## Summary
- remove the obsolete `fueltracker.egg-info` folder
- ensure `.gitignore` explicitly ignores `fueltracker.egg-info/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a6a9348188333b70c51a19e8ff42c