### PR TITLE
Add PyPDF2 and tufup to dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dev = [
     "pytest-qt",
     "pytest-cov",
     "pytest-xdist",
+    "PyPDF2",
+    "tufup",
 
     # Type Stubs
     "types-requests",

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,8 +12,16 @@ appdirs==1.4.4
     # via fueltracker (pyproject.toml)
 black==25.1.0
     # via fueltracker (pyproject.toml)
+bsdiff4==1.2.6
+    # via tufup
 certifi==2025.6.15
-    # via requests
+    # via
+    #   requests
+    #   tufup
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
 charset-normalizer==3.4.2
     # via
     #   reportlab
@@ -24,6 +32,10 @@ contourpy==1.3.2
     # via matplotlib
 coverage[toml]==7.9.1
     # via pytest-cov
+cryptography==45.0.4
+    # via
+    #   securesystemslib
+    #   tufup
 cycler==0.12.1
     # via matplotlib
 defusedxml==0.7.1
@@ -82,6 +94,7 @@ packaging==25.0
     #   black
     #   matplotlib
     #   pytest
+    #   tufup
 pandas==2.3.0
     # via fueltracker (pyproject.toml)
 pastel==0.2.1
@@ -104,6 +117,8 @@ pluggy==1.6.0
     #   pytest-qt
 poethepoet==0.35.0
     # via fueltracker (pyproject.toml)
+pycparser==2.22
+    # via cffi
 pydantic==2.11.7
     # via
     #   pydantic-settings
@@ -116,8 +131,12 @@ pygments==2.19.2
     # via
     #   pytest
     #   rich
+pynacl==1.5.0
+    # via securesystemslib
 pyparsing==3.2.3
     # via matplotlib
+pypdf2==3.0.1
+    # via fueltracker (pyproject.toml)
 pyside6==6.9.1
     # via
     #   fueltracker (pyproject.toml)
@@ -157,11 +176,17 @@ pyyaml==6.0.2
 reportlab==4.4.2
     # via fueltracker (pyproject.toml)
 requests==2.32.4
-    # via fueltracker (pyproject.toml)
+    # via
+    #   fueltracker (pyproject.toml)
+    #   tuf
 rich==14.0.0
     # via fueltracker (pyproject.toml)
 ruff==0.12.0
     # via fueltracker (pyproject.toml)
+securesystemslib[crypto,pynacl]==0.31.0
+    # via
+    #   tuf
+    #   tufup
 shiboken6==6.9.1
     # via
     #   pyside6
@@ -174,6 +199,10 @@ sqlalchemy==2.0.41
     #   alembic
     #   sqlmodel
 sqlmodel==0.0.24
+    # via fueltracker (pyproject.toml)
+tuf==4.0.0
+    # via tufup
+tufup==0.9.0
     # via fueltracker (pyproject.toml)
 types-keyboard==0.13.2.20240310
     # via fueltracker (pyproject.toml)
@@ -203,3 +232,6 @@ urllib3==2.5.0
     #   types-requests
 vulture==2.14
     # via fueltracker (pyproject.toml)
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
## Summary
- ensure PyPDF2 and tufup get installed with the `dev` extras
- regenerate the development lock file

## Testing
- `pip install -e .[dev]`
- `pytest tests/test_export_service.py::test_export_service_outputs -q`

------
https://chatgpt.com/codex/tasks/task_e_685a72f83bd88333b20472ded55f4301