### PR TITLE
Fix backup path creation

### DIFF
--- a/src/services/storage_service.py
+++ b/src/services/storage_service.py
@@ -619,10 +619,9 @@ class StorageService:
             raise RuntimeError("StorageService is not file-based")
 
         now = now or datetime.now()
-        from pathlib import PosixPath
 
-        home_path = PosixPath(os.path.expanduser("~"))
-        backup_dir = PosixPath(backup_dir or home_path / ".fueltracker" / "backups")
+        home_path = Path.home()
+        backup_dir = Path(backup_dir or home_path / ".fueltracker" / "backups")
         backup_dir.mkdir(parents=True, exist_ok=True)
 
         backup_path = backup_dir / now.strftime("%y-%m-%d_%H%M.db")


### PR DESCRIPTION
## Summary
- ensure `auto_backup` uses `Path` and `Path.home()` so that backup directories
  work on Windows and POSIX

## Testing
- `pip install -r requirements.lock`
- `pytest -n auto` *(fails: OperationalError table already exists)*

------
https://chatgpt.com/codex/tasks/task_e_685aad8f8f2c8333ad56b8897502c49b