### PR TITLE
Fix unused mypy ignores

### DIFF
--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -71,12 +71,12 @@ class ReportService:
     # New functionality for exporting monthly reports
     # ------------------------------------------------------------------
 
-    def _filter_entries(self, month: date, vehicle_id: int) -> List[FuelEntry]:
+    def _filter_entries(self, month: date, vehicle_id: int | None) -> List[FuelEntry]:
         """ดึงรายการของยานพาหนะในเดือนที่กำหนด"""
         return self.storage.list_entries_for_month(month.year, month.month, vehicle_id)
 
     # FIX: mypy clean
-    def _monthly_df(self, month: date, vehicle_id: int) -> DataFrame:
+    def _monthly_df(self, month: date, vehicle_id: int | None) -> DataFrame:
         """Return monthly entries as a :class:`pandas.DataFrame`."""
         key = (month.strftime("%Y-%m"), vehicle_id)
         ts = getattr(self.storage, "last_modified", None)

--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -8,11 +8,11 @@ from PySide6.QtWidgets import QApplication
 
 # Provide Qt5-style reexports for Qt6 compatibility
 if not hasattr(QtWidgets, "QAction"):
-    QtWidgets.QAction = QtGui.QAction  # type: ignore[attr-defined]
+    QtWidgets.QAction = QtGui.QAction
 if not hasattr(QtWidgets, "QStandardItemModel"):
-    QtWidgets.QStandardItemModel = QtGui.QStandardItemModel  # type: ignore[attr-defined]
+    QtWidgets.QStandardItemModel = QtGui.QStandardItemModel
 if not hasattr(QtWidgets, "QStandardItem"):
-    QtWidgets.QStandardItem = QtGui.QStandardItem  # type: ignore[attr-defined]
+    QtWidgets.QStandardItem = QtGui.QStandardItem
 
 from .main_window import MainWindow
 from .dialogs import (

--- a/src/views/reports_page.py
+++ b/src/views/reports_page.py
@@ -106,7 +106,7 @@ class _Worker(QThread):
         yearly = self._service.last_year_summary()
         pie = self._service.liters_by_type()
         monthly = self._service.monthly_summary()
-        table = self._service._monthly_df(today, self._vehicle_id)  # type: ignore[arg-type]
+        table = self._service._monthly_df(today, self._vehicle_id)
 
         # Weekly breakdown by ISO week
         weekly = self._weekly(table)


### PR DESCRIPTION
## Summary
- remove obsolete `type: ignore` comments in `views`
- allow optional vehicle_id in report service

## Testing
- `python -m mypy src/ --strict` *(fails: missing Qt and SQLModel stubs)*
- `python -m pytest -n auto -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_685b4d40f75083338261a1f21b8eeb18