### PR TITLE
Fix mypy cache key for monthly reports

### DIFF
--- a/src/services/report_service.py
+++ b/src/services/report_service.py
@@ -38,7 +38,7 @@ date2num = cast(Callable[[date], float], mdates.date2num)
 class ReportService:
     def __init__(self, storage: StorageService) -> None:
         self.storage = storage
-        self._monthly_cache: dict[tuple[str, int], DataFrame] = {}
+        self._monthly_cache: dict[tuple[str, int | None], DataFrame] = {}
         self._monthly_cache_ts: float | None = None
         self._weekly_cache: dict[tuple[str, int], DataFrame] = {}
         self._weekly_cache_ts: float | None = None


### PR DESCRIPTION
## Summary
- support caching reports when vehicle_id is `None`

## Testing
- `mypy src`
- `pytest -q` *(fails: cannot import name 'QUndoStack' from 'QtGui')*

------
https://chatgpt.com/codex/tasks/task_e_685b59e68f9483338a94ba258126779e