### PR TITLE
Remove unused report service methods

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -45,6 +45,8 @@ _ = (
     tests.test_launcher_update.qt_widgets.QProgressBar,
     tests.test_launcher_update.qt_widgets.QSplashScreen,
     tests.test_launcher_update.qt_gui.QPixmap,
+    tests.conftest.pytest_sessionstart,
+    tests.conftest._cleanup_db,
 )
 
 __all__ = ["_"]


### PR DESCRIPTION
## Summary
- drop unused ReportService weekly report and benchmark helpers
- whitelist pytest hooks so lint passes

## Testing
- `poetry run poe lint`

------
https://chatgpt.com/codex/tasks/task_e_685b633289708333bc1c5f9c99ee50be