### PR TITLE
Fix sqlite URI in tests for xdist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,10 +59,11 @@ def in_memory_storage():
 
 
 @pytest.fixture(scope="session")
-def migrated_db_session():
+def migrated_db_session(pytestconfig):
     """Return a context manager yielding sessions on a migrated in-memory database."""
+    worker = pytestconfig.workerinput.get("workerid", "main")
     engine = create_engine(
-        "sqlite:///file:memdb1?mode=memory&cache=shared",
+        f"sqlite:///file:memdb_{worker}?mode=memory&cache=shared",
         connect_args={"check_same_thread": False, "uri": True},
         poolclass=StaticPool,
     )


### PR DESCRIPTION
## Summary
- isolate Alembic migrations per worker by naming the in-memory DB after the pytest worker

## Testing
- `pytest -n auto` *(fails: 24 failed, 67 passed, 2 skipped, 1 warning, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b6f3cd0d48333b2757b78d8782692