### PR TITLE
Fix worker isolation in migrated_db_session fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,11 +59,10 @@ def in_memory_storage():
 
 
 @pytest.fixture(scope="session")
-def migrated_db_session(pytestconfig):
+def migrated_db_session(worker_id: str):
     """Return a context manager yielding sessions on a migrated in-memory database."""
-    worker = pytestconfig.workerinput.get("workerid", "main")
     engine = create_engine(
-        f"sqlite:///file:memdb_{worker}?mode=memory&cache=shared",
+        f"sqlite:///file:memdb_{worker_id}?mode=memory&cache=shared",
         connect_args={"check_same_thread": False, "uri": True},
         poolclass=StaticPool,
     )


### PR DESCRIPTION
## Summary
- use `worker_id` fixture in `migrated_db_session`
- construct a per-worker SQLite memory DB URL

## Testing
- `pytest tests/test_migration.py -vv -q`
- `pytest tests/test_storage.py::test_vehicle_crud -vv -q`


------
https://chatgpt.com/codex/tasks/task_e_685b70ae3880833392ed4e6f7563a8a9