### PR TITLE
Update pytest config for parallel test execution

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = -vv
+addopts = -vv -n auto
 filterwarnings = ignore::DeprecationWarning


### PR DESCRIPTION
## Summary
- enable parallel execution with `-n auto`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_685b77ef70488333ad772d843a74e531