### PR TITLE
Fix maintenance notification test

### DIFF
--- a/tests/test_maintenance_notification.py
+++ b/tests/test_maintenance_notification.py
@@ -1,5 +1,7 @@
 from datetime import date
 from PySide6.QtWidgets import QMessageBox
+from pathlib import Path, PosixPath
+import tempfile
 
 from src.controllers import main_controller as main_module
 from src.models import Vehicle, Maintenance
@@ -18,11 +20,13 @@ def test_maintenance_notification(main_controller, monkeypatch):
     )
     show = {}
     monkeypatch.setattr(main_module.os, "name", "nt", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: PosixPath(tempfile.gettempdir()))
     monkeypatch.setattr(
         main_module.ToastNotifier,
         "show_toast",
         lambda *a, **k: show.setdefault("t", True),
     )
     ctrl._notify_due_maintenance(1, 120, date.today())
+    monkeypatch.setattr(ctrl, "cleanup", lambda: None)
     assert notified.get("n")
     assert show.get("t")


### PR DESCRIPTION
## Summary
- adjust maintenance notification test for Windows paths
- patch `Path.home` to use a temp directory on Linux
- avoid cleanup during the test so teardown doesn't fail

## Testing
- `pytest -q tests/test_maintenance_notification.py`

------
https://chatgpt.com/codex/tasks/task_e_685b843b3d108333ac34dc24cd2cbf44