### PR TITLE
Fix os.name restoration in maintenance test

### DIFF
--- a/tests/test_maintenance_notification.py
+++ b/tests/test_maintenance_notification.py
@@ -17,6 +17,7 @@ def test_maintenance_notification(main_controller, monkeypatch):
         QMessageBox, "information", lambda *a, **k: notified.setdefault("n", True)
     )
     show = {}
+    original = main_module.os.name
     monkeypatch.setattr(main_module.os, "name", "nt", raising=False)
     monkeypatch.setattr(
         main_module.ToastNotifier,
@@ -24,5 +25,6 @@ def test_maintenance_notification(main_controller, monkeypatch):
         lambda *a, **k: show.setdefault("t", True),
     )
     ctrl._notify_due_maintenance(1, 120, date.today())
+    monkeypatch.setattr(main_module.os, "name", original, raising=False)
     assert notified.get("n")
     assert show.get("t")


### PR DESCRIPTION
## Summary
- ensure `os.name` is reset after calling `_notify_due_maintenance`

## Testing
- `pytest tests/test_maintenance_notification.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b853a5e188333ae32d5f5e207c4eb