### PR TITLE
Handle missing PySide6 gracefully

### DIFF
--- a/src/fueltracker/main.py
+++ b/src/fueltracker/main.py
@@ -67,9 +67,13 @@ def run(argv: list[str] | None = None) -> None:
     )
     if args.check:
         os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    from PySide6.QtWidgets import QApplication
-    from PySide6.QtCore import QCoreApplication, Qt, QLocale
-    from PySide6.QtGui import QFont, QFontDatabase
+    try:
+        from PySide6.QtWidgets import QApplication
+        from PySide6.QtCore import QCoreApplication, Qt, QLocale
+        from PySide6.QtGui import QFont, QFontDatabase
+    except ImportError:
+        print("PySide6 is required")
+        raise SystemExit(1)
 
     app = QApplication.instance()
     if not isinstance(app, QApplication):


### PR DESCRIPTION
## Summary
- print a friendly message when PySide6 can't be imported
- add regression test for missing PySide6

## Testing
- `pre-commit run --files src/fueltracker/main.py tests/test_entrypoint.py` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_685b9ae2db988333a63ea0bb585883ec