### PR TITLE
Fix misplaced imports

### DIFF
--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,5 +1,9 @@
+import builtins
+import sys
 import tomllib
 from pathlib import Path, Path as _P
+
+import pytest
 
 from fueltracker.main import run
 
@@ -54,9 +58,6 @@ def test_sync_command(monkeypatch, tmp_path):
     )
 
 
-import builtins
-import sys
-import pytest
 
 
 def test_run_requires_pyside(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- fix E402 warnings by moving imports to top of `tests/test_entrypoint.py`

## Testing
- `python -m ruff check tests/test_entrypoint.py`
- `python -m pytest -n auto -q` *(fails: QtWidgets missing QStackedLayout, plus multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685ba32341508333b83a4d85716123be