### PR TITLE
Fix PySide6 QStackedLayout shim

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,13 @@
-"""รากแพ็กเกจของ FuelTracker"""
+"""FuelTracker package root – global compatibility shims."""
+
+from importlib import import_module
+
+try:
+    # Ensure PySide6 is importable in headless CI
+    QtWidgets = import_module("PySide6.QtWidgets")
+    if not hasattr(QtWidgets, "QStackedLayout"):
+        from PySide6.QtWidgets import QStackedLayout  # noqa: F401
+        QtWidgets.QStackedLayout = QStackedLayout
+except ModuleNotFoundError:
+    # PySide6 not available during some static analysis; ignore.
+    pass


### PR DESCRIPTION
## Summary
- add a global shim for `QtWidgets.QStackedLayout`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfb51abf08333b5420740d8530850