### PR TITLE
Set Qt platform plugin for headless testing

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,2 @@
+import os
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ import os
 import sys
 from pathlib import Path
 
+# Ensure Qt runs in headless mode before importing PySide6
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 import pytest
 from sqlmodel import SQLModel, Session, create_engine
 from contextlib import contextmanager
@@ -47,8 +50,9 @@ _hotkey.keyboard = None
 
 
 def pytest_sessionstart(session):
-    """Ensure Qt runs in headless mode for all tests."""
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    """Set up the test session."""
+    # Environment already configured for headless Qt
+    pass
 
 
 from src.services import StorageService  # noqa: E402


### PR DESCRIPTION
## Summary
- ensure tests run Qt in offscreen mode by default
- provide `sitecustomize.py` that sets `QT_QPA_PLATFORM`

## Testing
- `pytest -n0` *(fails: ImportError: cannot import name 'QUndoStack' from 'QtGui')*

------
https://chatgpt.com/codex/tasks/task_e_685bfacb0d4c8333958b02761d96d329