### PR TITLE
Fix ruff lint errors in launcher tests

### DIFF
--- a/tests/test_launcher_update.py
+++ b/tests/test_launcher_update.py
@@ -49,7 +49,6 @@ class DummyUpdater:
 def test_update_install(monkeypatch, tmp_path):
     _patch_pyside(monkeypatch)
 
-    import importlib
     importlib.reload(launcher)
 
     monkeypatch.setattr(launcher, "APP_DIR", tmp_path)


### PR DESCRIPTION
## Summary
- fix unused import and redefinition warnings in `test_launcher_update`

## Testing
- `poetry run python -m ruff check tests/test_launcher_update.py`
- `poetry run python -m ruff check .`
- `poetry run poe test`

------
https://chatgpt.com/codex/tasks/task_e_685c0d82ef388333a132703fc74fcab5