### PR TITLE
Fix vulture warning in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,12 @@ if PYSIDE_AVAILABLE:
 warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"PyPDF2")
 warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"fpdf\\..*")
 
-A_FIXTURE_MARKER = object()
 
 @pytest.fixture(scope="session")
 def worker_id() -> str:
     """Provide default worker id when pytest-xdist is absent."""
     return "master"
+
 
 ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
 


### PR DESCRIPTION
## Summary
- remove unused variable from tests

## Testing
- `mypy src`
- `pytest tests/test_config.py::test_config_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb54b0b84833391115c252374ab18