### PR TITLE
Fix import order in export service test

### DIFF
--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -1,20 +1,19 @@
 from datetime import date
 from pathlib import Path
+import warnings
 
 import matplotlib
 from matplotlib import font_manager
 import matplotlib.pyplot as plt
+from PyPDF2 import PdfReader
 import pandas as pd
-import warnings
-
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="PyPDF2")
-
-from PyPDF2 import PdfReader  # noqa: E402
 from reportlab.pdfbase import pdfmetrics
 
 from src.models import FuelEntry, Vehicle
 from src.services.export_service import ExportService
 from src.services.storage_service import StorageService
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="PyPDF2")
 
 
 


### PR DESCRIPTION
## Summary
- resolve E402 warnings by reordering imports in `test_export_service`

## Testing
- `python -m ruff check tests/test_export_service.py`
- `python -m pytest tests/test_export_service.py::test_export_service_outputs -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd66c882c8333afd4af634d3c4996