### PR TITLE
Fix vulture warnings

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -51,7 +51,10 @@ _ = (
     tests.test_launcher_update.qt_widgets.QProgressBar,
     tests.test_launcher_update.qt_widgets.QSplashScreen,
     tests.test_launcher_update.qt_gui.QPixmap,
+    tests.conftest._unraisable_hook,
     tests.conftest.pytest_sessionstart,
+    tests.conftest.pytest_sessionfinish,
+    tests.conftest.pytest_configure,
     tests.conftest._cleanup_db,
     _dummy_axid,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,10 +52,12 @@ def _unraisable_hook(unraisable: object) -> None:
 
 
 sys.unraisablehook = _unraisable_hook
+_ = sys.unraisablehook  # avoid vulture false positive
 
 
 def pytest_sessionfinish(session, exitstatus):
     """Clean up any temporary dirs left by third-party libraries."""
+    _ = exitstatus  # avoid vulture false positive
     import glob
     import shutil
 
@@ -118,6 +120,7 @@ def pytest_configure(config):
         _config.stash[ue.unraisable_exceptions].clear()
 
     ue.collect_unraisable = _ignore
+    _ = ue.collect_unraisable  # avoid vulture false positive
 
 
 from src.services import StorageService  # noqa: E402


### PR DESCRIPTION
## Summary
- mark pytest hooks as used to silence vulture
- reference vulture exceptions in whitelist

## Testing
- `python -m ruff check .`
- `python -m mypy src/ --strict`
- `python -m vulture src tests .vulture-whitelist.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cf0acbfe08333b3e1834a979efc27