### PR TITLE
Refactor hotkey callback

### DIFF
--- a/src/hotkey.py
+++ b/src/hotkey.py
@@ -67,15 +67,13 @@ class GlobalHotkey(QObject):
         """Invoke ``_wrapped_callback`` and always return ``1`` for Win32 hooks."""
         # Qt expects a Win32 hook callback to return an ``int``. Failing to do so
         # results in ``TypeError: WPARAM is simple, so must be an int object`` on
-        # Windows.  Using ``finally`` guarantees an integer is returned on every
-        # execution path.
+        # Windows.
         try:
             self._wrapped_callback(*args)
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("ข้อผิดพลาดตัวแปลงฮอตคีย์: %s", exc)
-        finally:
-            # Always return ``1`` to satisfy the Win32 hook requirement
-            return 1
+        # Always return ``1`` to satisfy the Win32 hook requirement
+        return 1
 
     def _wrapped_callback(self, *args: object) -> None:
         """Emit the hotkey signal."""


### PR DESCRIPTION
## Summary
- ensure `_callback_adapter` returns `1` after try/except, not inside a finally block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d068f53d883338a488af6eb15cc42