### PR TITLE
Use env var in worker_id fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,8 +86,8 @@ warnings.filterwarnings(
 
 @pytest.fixture(scope="session")
 def worker_id() -> str:
-    """Provide default worker id when pytest-xdist is absent."""
-    return "master"
+    """Provide a worker id for pytest-xdist in-memory databases."""
+    return os.environ.get("PYTEST_XDIST_WORKER", "master")
 
 
 ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"


### PR DESCRIPTION
## Summary
- enable xdist per-worker DBs by reading `PYTEST_XDIST_WORKER` in the `worker_id` fixture

## Testing
- `pip install -r requirements.lock`
- `pytest tests/test_config.py::test_config_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_685e08f8d97483338efd283a0ff83f33