### PR TITLE
Fix PyInstaller call for onefile build

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -3,7 +3,7 @@ setlocal
 
 
 REM Build FuelTracker with PyInstaller
-pyinstaller --noconfirm --clean --onefile fueltracker.spec
+pyinstaller --noconfirm --clean fueltracker.spec
 
 REM Optionally sign the binary if SIGNTOOL and CERT_PATH are set
 IF NOT "%SIGNTOOL%"=="" IF NOT "%CERT_PATH%"=="" (

--- a/fueltracker.spec
+++ b/fueltracker.spec
@@ -49,24 +49,17 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,
     a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
     [],
-    exclude_binaries=True,
     name='FuelTracker',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
     console=False,
     icon='assets/app.ico',
-)
-
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    strip=False,
-    upx=True,
-    upx_exclude=[],
-    name='FuelTracker',
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,9 +81,9 @@ migrate = { cmd = "python -m fueltracker migrate", env = { PYTHONPATH = "src" },
 test = { cmd = "python -m pytest -n auto -q", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite" }
 cover = { cmd = "python -m pytest -n auto --cov=src --cov-report=term-missing", deps = ["migrate"], env = { PYTHONPATH = "src" }, help = "Run test suite with coverage" }
 runtime-check = { cmd = "python -m fueltracker --check", env = { QT_QPA_PLATFORM = "offscreen", PYTHONPATH = "src" }, help = "Run app in headless mode" }
-build = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build standalone executable" }
-build-app = { cmd = "python -m PyInstaller --noconfirm --clean --onefile fueltracker.spec", help = "Build main FuelTracker.exe" }
-build-launcher = { cmd = "python -m PyInstaller --noconfirm --clean --onefile launcher.spec", help = "Build the launcher executable" }
+build = { cmd = "python -m PyInstaller --noconfirm --clean fueltracker.spec", help = "Build standalone executable" }
+build-app = { cmd = "python -m PyInstaller --noconfirm --clean fueltracker.spec", help = "Build main FuelTracker.exe" }
+build-launcher = { cmd = "python -m PyInstaller --noconfirm --clean launcher.spec", help = "Build the launcher executable" }
 release = { shell = "poe build-app && poe build-launcher && zip -j dist/FuelTracker-${VERSION}-win64.zip dist/FuelTracker.exe && tufup repo targets add ${VERSION} dist/FuelTracker-${VERSION}-win64.zip && tufup repo sign timestamp && gh release create ${VERSION} dist/FuelTracker-${VERSION}-win64.zip --draft", help = "Create release" }
 validate = { sequence = ["lint", "test"], help = "Run linters then tests" }
 report = { sequence = ["lint", "test", "runtime-check"], help = "Run all checks" }


### PR DESCRIPTION
## Summary
- update PyInstaller commands to avoid `--onefile` with .spec files
- convert `fueltracker.spec` to use the onefile layout

## Testing
- `python -m PyInstaller --noconfirm --clean fueltracker.spec` *(fails: Unable to find '/workspace/FuelTracker/src/views/*.ui' when adding binary and data files)*

------
https://chatgpt.com/codex/tasks/task_e_685e1d3dafb08333be4317ff8d11f7a4