### PR TITLE
Fix pyinstaller entry path

### DIFF
--- a/build/build_win.bat
+++ b/build/build_win.bat
@@ -22,7 +22,7 @@ pyinstaller ^
   --icon assets\fuel.ico ^
   --add-data "tuf_metadata\\root.json;tuf_metadata" ^
   --version-file build\version_final.txt ^
-  src\fueltracker\__main__.py
+  fueltracker\__main__.py
 
 if exist dist\FuelTracker\FuelTracker.exe (
     echo Build succeeded: dist\FuelTracker\FuelTracker.exe

--- a/fueltracker.spec
+++ b/fueltracker.spec
@@ -25,7 +25,7 @@ if not os.path.exists(ICON_PATH):
 
 
 a = Analysis(
-    ['src/fueltracker/__main__.py'],
+    ['fueltracker/__main__.py'],
     pathex=[],
     binaries=[],
     datas=[


### PR DESCRIPTION
## Summary
- update the spec file to use `fueltracker/__main__.py`
- update Windows build script to reference the new entry point

## Testing
- `pyinstaller fueltracker.spec`

------
https://chatgpt.com/codex/tasks/task_e_685e2a90a1a88333af1fc77e29fa662f