### PR TITLE
fix build script path

### DIFF
--- a/build/build_win.bat
+++ b/build/build_win.bat
@@ -22,6 +22,7 @@ pyinstaller ^
   --icon assets\fuel.ico ^
   --add-data "tuf_metadata\\root.json;tuf_metadata" ^
   --version-file build\version_final.txt ^
+  --paths src ^
   fueltracker\__main__.py
 
 if exist dist\FuelTracker\FuelTracker.exe (


### PR DESCRIPTION
## Summary
- ensure pyinstaller can locate the src packages by passing `--paths src` in `build_win.bat`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685e31a530b083338bfb479ef27680bc