### PR TITLE
Add ThemeManager palette change test

### DIFF
--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -1,0 +1,8 @@
+from src.services import ThemeManager
+
+
+def test_palette_changed_emitted(qtbot, qapp):
+    manager = ThemeManager(qapp)
+    with qtbot.waitSignal(manager.palette_changed, timeout=1000):
+        qapp.paletteChanged.emit(qapp.palette())
+


### PR DESCRIPTION
## Summary
- cover ThemeManager signal handling when the QApplication palette changes

## Testing
- `pytest tests/test_theme_manager.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e557cf2b48333a74afdd401417717