### PR TITLE
Fix PySide6 import handling

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,6 +9,6 @@ try:
         from PySide6.QtWidgets import QStackedLayout  # noqa: F401
 
         QtWidgets.QStackedLayout = QStackedLayout
-except ModuleNotFoundError:
+except Exception:
     # PySide6 not available during some static analysis; ignore.
     pass


### PR DESCRIPTION
## Summary
- broaden error handling when importing PySide6 modules so tests can run in headless setups

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1 and segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_685f3955e32083338270acc79467d63c