### PR TITLE
Handle in-memory SQLite URLs

### DIFF
--- a/tests/test_storage_memory.py
+++ b/tests/test_storage_memory.py
@@ -1,0 +1,26 @@
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, create_engine
+
+from src.services import StorageService
+
+
+def test_db_path_none_for_memory_engine() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    storage = StorageService(engine=engine)
+    assert storage._db_path is None
+
+
+def test_db_path_none_for_file_memory_engine() -> None:
+    engine = create_engine(
+        "sqlite:///file:memdb_test?mode=memory&cache=shared",
+        connect_args={"check_same_thread": False, "uri": True},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    storage = StorageService(engine=engine)
+    assert storage._db_path is None


### PR DESCRIPTION
## Summary
- treat memory engines specially in `StorageService`
- add tests verifying `_db_path` is `None` when using in-memory SQLite engines

## Testing
- `pytest -q tests/test_storage_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_685f746c906483338cfd3721039cd4f0