### PR TITLE
Handle in-memory backup errors

### DIFF
--- a/src/fueltracker/migrations/env.py
+++ b/src/fueltracker/migrations/env.py
@@ -2,8 +2,9 @@ from importlib import util
 from pathlib import Path
 
 # Delegate to the top-level Alembic env script
-_env = Path(__file__).resolve().parents[3] / 'alembic' / 'env.py'
-spec = util.spec_from_file_location('alembic.env', _env)
+_env = Path(__file__).resolve().parents[3] / "alembic" / "env.py"
+spec = util.spec_from_file_location("alembic.env", _env)
+assert spec is not None
 module = util.module_from_spec(spec)
 assert spec.loader
 spec.loader.exec_module(module)

--- a/src/services/oil_service.py
+++ b/src/services/oil_service.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, Optional, cast
 import os
 
-import requests
+import requests  # type: ignore[import-untyped]
 from sqlmodel import Session, select
 from sqlalchemy import delete
 

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from datetime import date
+from pathlib import Path
 from PySide6.QtWidgets import QApplication, QMainWindow
 from PySide6.QtGui import QCloseEvent
 from src.models import Vehicle, FuelEntry
@@ -80,3 +81,17 @@ def test_cleanup_unregisters_hotkey(main_controller):
     assert ctrl.global_hotkey is not None
     ctrl.cleanup()
     assert ctrl.global_hotkey is None
+
+
+def test_cleanup_handles_missing_db(main_controller, monkeypatch):
+    ctrl = main_controller
+
+    def fail_backup() -> Path:
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(ctrl.storage, "auto_backup", fail_backup)
+    called: list[tuple[Path, Path]] = []
+    monkeypatch.setattr(ctrl.storage, "sync_to_cloud", lambda *a: called.append(a))
+
+    ctrl.cleanup()
+    assert not called


### PR DESCRIPTION
## Summary
- suppress errors when `StorageService.auto_backup` fails
- guard window cleanup in `MainController`
- ensure migration env loads safely
- test backup error handling in controller

## Testing
- `pre-commit run ruff --files src/controllers/main_controller.py src/services/oil_service.py tests/test_backup.py tests/test_ui_smoke.py`
- `pre-commit run black --files src/controllers/main_controller.py src/services/oil_service.py tests/test_backup.py tests/test_ui_smoke.py`
- `pre-commit run mypy --files tests/test_backup.py tests/test_ui_smoke.py`
- `FT_DB_PASSWORD='test' pytest tests/test_backup.py tests/test_ui_smoke.py tests/test_updater_start.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7b094a348333a1ca9c928d0208b4