### PR TITLE
Fix mypy warnings

### DIFF
--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -68,7 +68,7 @@ import logging
 import os
 import sys
 from datetime import datetime
-import requests  # type: ignore[import-untyped]
+import requests
 import shutil
 
 from ..settings import Settings

--- a/src/services/oil_service.py
+++ b/src/services/oil_service.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, Optional, cast
 import os
 
-import requests  # type: ignore[import-untyped]
+import requests
 from sqlmodel import Session, select
 from sqlalchemy import delete
 


### PR DESCRIPTION
## Summary
- remove unused `# type: ignore` comments from imports

## Testing
- `poetry run mypy src/ --strict`

------
https://chatgpt.com/codex/tasks/task_e_685fabf0f1548333842fbc839066da0c