### PR TITLE
Fix updater test check

### DIFF
--- a/src/fueltracker/updater.py
+++ b/src/fueltracker/updater.py
@@ -22,7 +22,7 @@ _update_thread: Thread | None = None
 
 def _update_loop(interval: int) -> None:
     # Avoid contacting update servers when running under pytest
-    if os.getenv("PYTEST_RUNNING"):
+    if os.getenv("PYTEST_CURRENT_TEST"):
         return
 
     app_dir = data_dir()
@@ -48,7 +48,7 @@ def _update_loop(interval: int) -> None:
 def start_async(interval_hours: int = 24) -> None:
     """Start background update checking."""
     global _update_thread
-    if os.getenv("PYTEST_RUNNING"):
+    if os.getenv("PYTEST_CURRENT_TEST"):
         return
     if interval_hours <= 0:
         return

--- a/tests/test_updater_start.py
+++ b/tests/test_updater_start.py
@@ -29,6 +29,9 @@ def test_run_starts_background_updater(monkeypatch):
 
     monkeypatch.setattr(updater, "Thread", DummyThread)
 
+    # Allow updater.start_async() to run during this test
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "")
+
     main.run([])
 
     assert started.get("t")


### PR DESCRIPTION
## Summary
- detect pytest sessions via `PYTEST_CURRENT_TEST`
- allow updater tests to run while skipping network calls

## Testing
- `pytest tests/test_updater_start.py -q`
- `pytest tests/test_config.py -q`
- `timeout 30 pytest -q` *(partial run)*

------
https://chatgpt.com/codex/tasks/task_e_685fae82c2208333bc8caa02a52d7d79