### PR TITLE
Fix flaky export report test

### DIFF
--- a/tests/test_export_report_async.py
+++ b/tests/test_export_report_async.py
@@ -49,7 +49,8 @@ def test_export_report_runs_async(qtbot, main_controller, tmp_path, monkeypatch)
     elapsed = time.monotonic() - start
     assert elapsed < 0.05
 
-    with qtbot.waitSignal(ctrl.export_finished, timeout=2000):
+    # Increase timeout to avoid flakiness when running tests in parallel
+    with qtbot.waitSignal(ctrl.export_finished, timeout=10000):
         pass
 
 


### PR DESCRIPTION
## Summary
- increase waitSignal timeout in export report async test

## Testing
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68620597b3f8833396c90a9654074d1e