### PR TITLE
Fix PyInstaller build path

### DIFF
--- a/fueltracker.spec
+++ b/fueltracker.spec
@@ -31,7 +31,7 @@ a = Analysis(
     datas=[
         ('assets/*', 'assets'),
         ('alembic.ini', '.'),
-        ('fueltracker/migrations/*', 'fueltracker/migrations'),
+        ('src/fueltracker/migrations/*', 'fueltracker/migrations'),
     ],
     hiddenimports=[],
     hookspath=[],


### PR DESCRIPTION
## Summary
- correct migrations folder path in `fueltracker.spec`

## Testing
- `python -m PyInstaller --noconfirm --clean fueltracker.spec`

------
https://chatgpt.com/codex/tasks/task_e_686224409c0c8333b2749a7708dc4410