### PR TITLE
Fix PyInstaller build missing logging.config

### DIFF
--- a/fueltracker.spec
+++ b/fueltracker.spec
@@ -35,7 +35,7 @@ a = Analysis(
         ('alembic/versions/*', 'alembic/versions'),
         ('src/fueltracker/migrations/*', 'fueltracker/migrations'),
     ],
-    hiddenimports=[],
+    hiddenimports=["logging.config"],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],


### PR DESCRIPTION
## Summary
- include `logging.config` in the `hiddenimports` list for PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623dbc0c1483339b38a3d9491bfd92