### PR TITLE
Add CLI to fetch Thai oil prices

### DIFF
--- a/scripts/print_latest_oil_prices.py
+++ b/scripts/print_latest_oil_prices.py
@@ -1,0 +1,15 @@
+import json
+import requests
+
+API_URL = "https://api.chnwt.dev/thai-oil-api/latest"
+
+
+def main() -> None:
+    resp = requests.get(API_URL, timeout=5)
+    resp.raise_for_status()
+    data = resp.json()
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small helper script to print the latest oil prices
- maintain default oil API URL

## Testing
- `pip install -r requirements.lock`
- `pytest -q`
- `python scripts/print_latest_oil_prices.py | head`

------
https://chatgpt.com/codex/tasks/task_e_68625125f4908333974e0f56e0b9a985