### PR TITLE
Improve theme manager tests

### DIFF
--- a/tests/test_theme_manager.py
+++ b/tests/test_theme_manager.py
@@ -6,3 +6,21 @@ def test_palette_changed_emitted(qtbot, qapp):
     with qtbot.waitSignal(manager.palette_changed, timeout=1000):
         qapp.paletteChanged.emit(qapp.palette())
 
+
+def test_theme_to_file_mapping():
+    assert ThemeManager._theme_to_file("light") == "light.qss"
+    assert ThemeManager._theme_to_file("dark") == "dark.qss"
+    assert ThemeManager._theme_to_file("modern") == "modern.qss"
+    assert ThemeManager._theme_to_file("vivid") == "vivid.qss"
+    assert ThemeManager._theme_to_file("unknown") is None
+
+
+def test_apply_theme_invalid_does_nothing(qapp, monkeypatch):
+    manager = ThemeManager(qapp)
+    qapp.setStyleSheet("")
+    monkeypatch.setattr(
+        ThemeManager, "_theme_to_file", staticmethod(lambda _t: None)
+    )
+    manager.apply_theme("missing")
+    assert qapp.styleSheet() == ""
+


### PR DESCRIPTION
## Summary
- add unit tests covering ThemeManager mapping logic
- verify applying an unknown theme does not change the stylesheet

## Testing
- `pytest tests/test_theme_manager.py -q`
- `pytest tests/test_theme_manager.py --cov=src --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6863552d8f248333ac4bd04d9648a5d4