### PR TITLE
Improve test suite initialization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,11 @@ def pytest_configure(config):
 
 
 from src.services import StorageService  # noqa: E402
-from src.controllers.main_controller import MainController  # noqa: E402
+
+if PYSIDE_AVAILABLE:
+    from src.controllers.main_controller import MainController  # noqa: E402
+else:  # pragma: no cover - PySide6 not available
+    MainController = None  # type: ignore
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- avoid importing `MainController` when PySide6 isn't present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863659d6fe08333ac411d762cfe51b5