### PR TITLE
Refactor validator tests

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,33 +3,40 @@ from datetime import date
 import pytest
 
 from src.models import FuelEntry
+from src.services.storage_service import StorageService
 from src.services.validators import validate_entry
 
 
-def test_odo_after_less_than_before_raises():
+@pytest.mark.parametrize(
+    "odo_before, odo_after, amount_spent, liters, message",
+    [
+        (200.0, 100.0, 50.0, 5.0, "ค่าเลขไมล์หลังเติมต้องมากกว่าหรือเท่ากับก่อนเติม"),
+        (0.0, 50.0, None, 5.0, "ต้องระบุจำนวนเงินเมื่อระบุจำนวนลิตร"),
+    ],
+)
+def test_invalid_entries_raise(
+    odo_before: float,
+    odo_after: float | None,
+    amount_spent: float | None,
+    liters: float | None,
+    message: str,
+    in_memory_storage: StorageService,
+) -> None:
+    """Ensure invalid entries fail validation both directly and via storage."""
     entry = FuelEntry(
         entry_date=date.today(),
         vehicle_id=1,
-        odo_before=200.0,
-        odo_after=100.0,
-        amount_spent=50.0,
-        liters=5.0,
+        odo_before=odo_before,
+        odo_after=odo_after,
+        amount_spent=amount_spent,
+        liters=liters,
     )
-    with pytest.raises(ValueError, match="ค่าเลขไมล์หลังเติมต้องมากกว่าหรือเท่ากับก่อนเติม"):
+
+    with pytest.raises(ValueError, match=message):
         validate_entry(entry)
 
-
-def test_liters_without_amount_raises():
-    entry = FuelEntry(
-        entry_date=date.today(),
-        vehicle_id=1,
-        odo_before=0.0,
-        odo_after=50.0,
-        amount_spent=None,
-        liters=5.0,
-    )
-    with pytest.raises(ValueError, match="ต้องระบุจำนวนเงินเมื่อระบุจำนวนลิตร"):
-        validate_entry(entry)
+    with pytest.raises(ValueError, match=message):
+        in_memory_storage.add_entry(entry)
 
 
 def test_valid_entry_passes():


### PR DESCRIPTION
## Summary
- combine validation error scenarios with pytest parametrize
- verify StorageService.add_entry also raises expected errors

## Testing
- `ruff check tests/test_validators.py`
- `black --check tests/test_validators.py`
- `mypy --config-file mypy.ini src`
- `pytest tests/test_validators.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68637be32a588333b4c28c79acd3cf3b